### PR TITLE
Allow starting breakout by tapping overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -1593,6 +1593,10 @@ function drawBGDecor(){
     if(running){ startCountdown(); } else { startGameWithCountdown(); }
   }
   noteClose.addEventListener('click', (e)=>{ e.stopPropagation(); closeNoteAndResume(); });
+  // 玩家點擊提示視窗任意處也可開始／繼續遊戲
+  if (typeof centerNote !== 'undefined' && centerNote) {
+    centerNote.addEventListener('click', closeNoteAndResume);
+  }
 
 
   // === DPR 縮放 ===


### PR DESCRIPTION
## Summary
- allow starting or resuming play by tapping the instructions overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afbf28ad8883288a94f6bd0b8a321a