### PR TITLE
Fix game start overlay crash

### DIFF
--- a/index.html
+++ b/index.html
@@ -1576,6 +1576,9 @@ function drawBGDecor(){
   const bgmBtn=document.getElementById('bgmBtn'), bgmVol=document.getElementById('bgmVol');
   const gameover=document.getElementById('gameover'), finalScore2=document.getElementById('finalScore2');
   const retryBtn=document.getElementById('retryBtn');
+  const centerNote=document.getElementById('centerNote'),
+        noteTitle=document.getElementById('noteTitle'),
+        noteText=document.getElementById('noteText');
 
   /*
    * 新 UI 音效與 BGM 控制
@@ -1594,9 +1597,7 @@ function drawBGDecor(){
   }
   noteClose.addEventListener('click', (e)=>{ e.stopPropagation(); closeNoteAndResume(); });
   // 玩家點擊提示視窗任意處也可開始／繼續遊戲
-  if (typeof centerNote !== 'undefined' && centerNote) {
-    centerNote.addEventListener('click', closeNoteAndResume);
-  }
+  if(centerNote){ centerNote.addEventListener('click', closeNoteAndResume); }
 
 
   // === DPR 縮放 ===


### PR DESCRIPTION
## Summary
- define `centerNote`, `noteTitle`, and `noteText` DOM references
- ensure start overlay click starts or resumes game

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afff927a3c8328b4af1ce3b42b85f8