### PR TITLE
Fix keyboard paddle movement when game paused

### DIFF
--- a/index.html
+++ b/index.html
@@ -2570,8 +2570,20 @@ const def=GAME_CONFIG.powers[type]; if(!def) return; const now=performance.now()
   // === 輸入（含觸控） ===
   let keyL=false, keyR=false; let touchActive=false;
   window.addEventListener('keydown',(e)=>{ if(gameOver){ e.preventDefault(); return; }
-    if(e.code==='ArrowLeft'||e.key==='a'||e.key==='A') keyL=true;
-    if(e.code==='ArrowRight'||e.key==='d'||e.key==='D') keyR=true;
+    const left = (e.code==='ArrowLeft'||e.key==='a'||e.key==='A');
+    const right = (e.code==='ArrowRight'||e.key==='d'||e.key==='D');
+    if(left) keyL=true;
+    if(right) keyR=true;
+    // 若遊戲未進行或已暫停，允許以鍵盤立即移動擋板
+    if((!running || paused) && (left || right)){
+      if(!orientLeft){
+        if(left) paddle.x=Math.max(0, paddle.x-paddle.speed);
+        if(right) paddle.x=Math.min(1100-paddle.w, paddle.x+paddle.speed);
+      }else{
+        if(left) paddle.y=Math.max(0, paddle.y-paddle.speed);
+        if(right) paddle.y=Math.min(700-paddle.w, paddle.y+paddle.speed);
+      }
+    }
     if(e.code==='Space'){ // 開始 / 暫停 / 倒數
       if(!running){ startGameWithCountdown(); } else { togglePause(); }
       return;


### PR DESCRIPTION
## Summary
- Allow left/right keys to reposition paddle even when the game is paused or before starting
- Preserve existing space, reset, and fullscreen controls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b01ab122188328b5777005b8d4767d