### PR TITLE
fix: remove extraneous script for mobile load

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Rock打磚塊 Breakout（最終增強版）</title>
-  <script type="text/javascript" src="https://gc.kis.v2.scr.kaspersky-labs.com/FD126C42-EBFA-4E12-B309-BB3FDD723AC1/main.js?attr=7AZ9GDmdk-0nXflGBh_OSV4sbUY45NaCzZxEmVqbH7Xoa5XDaFySHgwINA_LKoYnTF-Tn0R31QrGwOed9CZ3OnvNc_qFz8_F8SsZHNBXvxPBQW9Ws4MMsapYX00pYtOHM5cR9iTy3FkOPbVcloFwV5-a4dnUqEiHa46LkjY7j77ICU6vp9MI_Ee0xq88-jqlk_Lc7TmXPpXFPDrdBDVq5xpeyXyeCeGW2qDiFIazeduFGfcwWHRoifZbFYWPMOlo" charset="UTF-8"></script><script type="text/javascript" src="https://gc.kis.v2.scr.kaspersky-labs.com/FD126C42-EBFA-4E12-B309-BB3FDD723AC1/main.js?attr=xpcCKmpP02pGpAdk4lURQozfYVx-VrJiimPXD3ZPoW9TIv1EzIua7bKjDuvLpPHY5MGoMNnz-RZNqInmE2AiGIv1FM8_RTM5oF19CfAA6TuNQNa3rPpVJLnwmci3doH8EuGNihYABQQUc5dUImRJArx-xrY4n8XP7tzZNKYcjrVE6OSgQt5EgZeGVJ11JygDLcAX--0dUZf8dggdbPhFsXbA-YBxJ4Dz5F3CMnNgJErVZJAS5LnFHwe5jJMlZVHU" charset="UTF-8"></script><style>
+  <style>
     /* 全面換用全新 UI 風格（取自 index_skin.html） */
     :root{
       --ink:#eaf2ff; --muted:#b8c7ea;


### PR DESCRIPTION
## Summary
- remove leftover Kaspersky script references that blocked page loading on mobile

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b4078fa8108328ab9302c4ddba93a4