### PR TITLE
Fix menu pause not resuming on menu close

### DIFF
--- a/index.html
+++ b/index.html
@@ -2549,8 +2549,10 @@ const def=GAME_CONFIG.powers[type]; if(!def) return; const now=performance.now()
         paused = true;
         onPauseStart();
       } else {
-        // 關閉選單：若遊戲正在進行且未進入結束，並且沒有倒數中，則恢復並倒數
-        if(running && !gameOver && !resumePending){
+        // 關閉選單：只要遊戲尚在進行且未 Game Over，立即修正計時並重新倒數
+        if(running && !gameOver){
+          // 確保即便先前已有倒數排程也能正確恢復
+          resumePending = false;
           onResumeFromPause();
           startCountdown();
         }


### PR DESCRIPTION
## Summary
- Ensure closing the sound or options menu always resumes gameplay
- Reset any pending countdown and restart it when menus close

## Testing
- `node -e "console.log('No tests available')"`


------
https://chatgpt.com/codex/tasks/task_e_68b5aa7832a08328b946d06145c4d099