### PR TITLE
Limit nine lives cat and tune drop rates

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,9 +111,11 @@
     .legend{display:flex;gap:8px;flex-wrap:wrap;align-items:center;justify-content:center;font-size:12px;color:#cfe0ff;margin-top:6px}
     .legend .item{padding:4px 8px;border-radius:10px;background:rgba(255,255,255,.05);border:1px solid var(--stroke);display:flex;align-items:center;gap:4px}
     .legend .box{width:14px;height:14px;border-radius:3px;display:inline-block;vertical-align:middle}
-    /* Hearts */
+    /* Hearts and Nine-cat history */
     .hearts{filter:drop-shadow(0 0 10px var(--heartGlow));display:inline-block}
     .hearts.compact .life-icon{width:14px;height:14px}
+    .cats{display:inline-block;margin-left:4px}
+    .cats .cat-icon{width:14px;height:14px;display:inline-block}
     /* Gallery and overlay (retain original styles) */
     .overlay{position:fixed;inset:0;z-index:40;pointer-events:none}
     .gallery{position:absolute;inset:0;display:none;align-items:center;justify-content:center;flex-direction:column;z-index:4;pointer-events:auto}
@@ -139,9 +141,13 @@
     .win .again{margin-top:10px}
     /* Note box */
     .center-note{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;pointer-events:auto;z-index:3}
-    .note-box{background:linear-gradient(180deg, rgba(8,12,28,.9), rgba(8,12,28,.85));border:1px solid var(--glass-stroke);padding:16px 18px;border-radius:14px;text-align:center;max-width:min(90vw,860px);box-shadow:0 12px 60px rgba(0,0,0,.5);font-size:14px;position:relative}
+    .note-box{background:linear-gradient(180deg, rgba(8,12,28,.9), rgba(8,12,28,.85));border:1px solid var(--glass-stroke);padding:16px 18px;border-radius:14px;text-align:center;max-width:min(90vw,860px);max-height:90vh;overflow:auto;box-shadow:0 12px 60px rgba(0,0,0,.5);font-size:14px;position:relative}
     .note-box h2{margin:0 0 8px 0;font-size:18px}
     .note-box p{margin:6px 0;line-height:1.6}
+    @media (max-width:480px){
+      .note-box{font-size:12px;}
+      .note-box h2{font-size:16px;}
+    }
     kbd{background:#0e1836;border:1px solid #2a356a;border-radius:6px;padding:2px 6px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:90%}
     .note-close{
       position:absolute;top:8px;right:8px;width:28px;height:28px;border-radius:999px;
@@ -300,7 +306,7 @@ select optgroup { color: #0b1022; }
             </select></div>
           </div>
         </div>
-        <div class="pill wide">生命 <b id="lives">3</b> <span class="hearts" id="hearts">❤️❤️❤️</span></div>
+        <div class="pill wide">生命 <b id="lives">3</b> <span class="hearts" id="hearts">❤️❤️❤️</span> <span class="cats" id="cats"></span></div>
       </div>
     </section>
     <div class="hud-sentinel" style="height:0"></div>
@@ -452,6 +458,7 @@ select optgroup { color: #0b1022; }
 
   // 新增元素參考
   const heartsEl = document.getElementById('hearts');
+  const catsEl = document.getElementById('cats');
   const totalLevelsEl = document.getElementById('totalLevels');
   const sfxOnEl = document.getElementById('sfxOn');
   const bgmOnEl = document.getElementById('bgmOn');
@@ -592,6 +599,7 @@ select optgroup { color: #0b1022; }
 
   // === 狀態 ===
   let running=false, paused=true, level=1, score=0, lives=3, soundsOn=false;
+  let nineCatEaten=0;
   let gameOver=false;
   let stats={catches:0,buffs:0,debuffs:0,eliteKills:0,bossKills:0,lifeStart:0,fastestDeath:Infinity,longestLife:0,livesUsed:0};
   let ledStyle = (localStorage.getItem('led_style')||'classic');
@@ -1317,13 +1325,26 @@ function generateLevel(lv, L){
     });
   }
 
-  
-
+  // 道具掉落率抑制
+  let burstStart=0, burstCount=0;
   function maybeDropFromBrick(b){
     if(!b || b.unbreakable) return;
     // Boss不會掉落一般增益（保持平衡）
     if(b.boss) return;
-    if(Math.random()<dropRateForLevel(level)) spawnPower(b.x + b.w/2 - 12, b.y + b.h/2);
+    const now=performance.now();
+    if(!burstStart || now-burstStart>500){
+      burstStart=now; burstCount=1;
+    }else{
+      burstCount++;
+    }
+    let rate=dropRateForLevel(level);
+    if(burstCount>=3){
+      const n=Math.min(burstCount,6);
+      let factor=1-0.2*(n-2);
+      if(factor<0.2) factor=0.2;
+      rate*=factor;
+    }
+    if(Math.random()<rate) spawnPower(b.x + b.w/2 - 12, b.y + b.h/2);
   }
 
   function dropRateForLevel(lv){
@@ -1343,7 +1364,8 @@ function generateLevel(lv, L){
     // 隨機挑選一種道具類型（普通或稀有），並根據類型設定掉落速度與顏色標記
     const rareChance = (GAME_CONFIG.powers.PHOENIX?.rareFactor) || 0.1;
     const pickRare = RARE_TYPES.length && Math.random() < rareChance;
-    const pool = pickRare ? RARE_TYPES : NORMAL_TYPES;
+    const pool = pickRare ? RARE_TYPES.filter(t=>t!=='NINE'||nineCatEaten<2) : NORMAL_TYPES;
+    if(!pool.length) return;
     const type = pool[Math.floor(Math.random()*pool.length)];
     const def = GAME_CONFIG.powers[type];
     if(!def) return;
@@ -1399,7 +1421,7 @@ const def=GAME_CONFIG.powers[type]; if(!def) return; const now=performance.now()
           } else keep.push(b);
         }
         bricks=keep; screenShake=6; beep(180,0.12,0.1);
-      } else if(type==='NINE'){ lives=9; updateHUD(); spawnParticles(550,350,'#ffd',40,2.2,3.5,4); beep(880,0.1,0.06); }
+      } else if(type==='NINE'){ if(nineCatEaten>=2) return; lives=9; nineCatEaten++; updateHUD(); spawnParticles(550,350,'#ffd',40,2.2,3.5,4); beep(880,0.1,0.06); }
       return;
     }
     // 定時類
@@ -1469,6 +1491,15 @@ const def=GAME_CONFIG.powers[type]; if(!def) return; const now=performance.now()
       // 過多生命時採用 compact 風格
       heartsEl.classList.toggle('compact', lives > 5);
     }
+    if (catsEl) {
+      catsEl.innerHTML = '';
+      for (let i = 0; i < nineCatEaten; i++) {
+        const span = document.createElement('span');
+        span.textContent = '🐱';
+        span.className = 'cat-icon';
+        catsEl.appendChild(span);
+      }
+    }
   }
   function showCenter(t, txt){
     noteTitle.textContent = t;
@@ -1484,7 +1515,7 @@ const def=GAME_CONFIG.powers[type]; if(!def) return; const now=performance.now()
   }
   function hideCenter(){ centerNote.style.display='none'; }
 
-  function resetGame(load=false){ diff=getDiff(); level=load?level:1; score=load?score:0; lives=load?lives:3; updateHUD(); initBricks(); resetBalls(); paused=true; running=false;
+  function resetGame(load=false){ diff=getDiff(); level=load?level:1; score=load?score:0; lives=load?lives:3; nineCatEaten=load?nineCatEaten:0; updateHUD(); initBricks(); resetBalls(); paused=true; running=false;
     for(const k of Object.keys(buffs)){
       if(k!=='LONG'){
         buffs[k].active=false;


### PR DESCRIPTION
## Summary
- Restrict nine lives cat to two pickups per run and show cat icons for each use
- Suppress item drops during rapid brick clears to avoid excessive powerups
- Adjust effect description overlay for better readability on mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d76eebd88328aea9911ae8baf913