### PR TITLE
style: reposition prompt cards for responsive layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,26 +94,39 @@
       padding:6px 10px;border:1px solid var(--stroke);border-radius:999px;
       background:var(--glass-1);font-size:12px;white-space:nowrap;color:#cfe0ff
     }
+    #playArea{
+      position:relative;
+      max-width:min(1080px,96vw);
+      margin:12px auto 0;
+      padding-top:72px;
+    }
     #promptsDock{
-      position:sticky;z-index:20;top:calc(var(--hudBottom) + 48px);
-      max-width:min(1080px,96vw);margin:6px auto 0;padding:0 6px;
-      display:flex;gap:8px;align-items:flex-start;overflow:auto;scrollbar-width:none;
-      flex-direction:row
+      position:absolute;left:0;right:0;top:0;z-index:20;
+      display:flex;gap:8px;justify-content:center;padding:0 6px;
+      overflow:hidden;
     }
-    @media (min-width:768px){
-      #promptsDock{flex-direction:column}
-    }
-    #promptsDock::-webkit-scrollbar{display:none}
-    .prompt{
+    #promptsDock .prompt{
+      flex:1 1 auto;
+      min-width:80px;height:48px;
       padding:8px 10px;border:1px solid var(--stroke);border-radius:12px;
       background:rgba(14,22,40,.92);box-shadow:0 10px 26px rgba(0,0,0,.34);
       font-size:12px;line-height:1.45;color:#eaf2ff;white-space:normal;
       display:flex;align-items:center;justify-content:center;text-align:center;
       opacity:1;transition:opacity .4s
     }
-    .prompt.fade{opacity:0}
+    #promptsDock .prompt.fade{opacity:0}
+    @media (min-width:768px){
+      #playArea{padding-top:0;display:flex;gap:12px;align-items:flex-start;}
+      #promptsDock{
+        position:absolute;top:0;left:-200px;right:auto;width:180px;
+        flex-direction:column;justify-content:flex-start;
+      }
+      #promptsDock .prompt{
+        width:100%;height:60px;flex:none;
+      }
+    }
     /* Stage */
-    .stage{position:relative;margin:12px auto 0;max-width:min(1080px,96vw);border-radius:18px;padding:12px;box-sizing:border-box;background:var(--stageGlass);background-image:var(--panelPattern);background-blend-mode:overlay;}
+    .stage{position:relative;margin:0 auto 0;max-width:100%;border-radius:18px;padding:12px;box-sizing:border-box;background:var(--stageGlass);background-image:var(--panelPattern);background-blend-mode:overlay;}
     canvas#game{background:linear-gradient(180deg,#0d132a,#0b1226 55%, #091223);border:1px solid rgba(80,110,170,.45);border-radius:16px;display:block;width:100%;height:auto;margin:0 auto;box-shadow:inset 0 0 160px rgba(255,255,255,.03), 0 28px 90px rgba(0,0,0,.46);touch-action:none;}
     .legend{display:flex;gap:8px;flex-wrap:wrap;align-items:center;justify-content:center;font-size:12px;color:#cfe0ff;margin-top:6px}
     .legend .item{padding:4px 8px;border-radius:10px;background:rgba(255,255,255,.05);border:1px solid var(--stroke);display:flex;align-items:center;gap:4px}
@@ -319,12 +332,13 @@ select optgroup { color: #0b1022; }
     <div class="hud-sentinel" style="height:0"></div>
     <!-- Buffs / 提示 -->
     <div id="buffs" class="badges"></div>
-    <div id="promptsDock"></div>
-    <!-- 遊戲區域 -->
-    <div class="stage">
-      <canvas id="fx"></canvas>
+    <div id="playArea">
+      <div id="promptsDock"></div>
+      <!-- 遊戲區域 -->
+      <div class="stage">
+        <canvas id="fx"></canvas>
 <canvas id="game" width="1100" height="700"></canvas>
-      <div class="legend">
+        <div class="legend">
         <span class="item"><span class="box" style="background:var(--expl)"></span>爆炸磚</span>
         <span class="item"><span class="box" style="background:var(--brick2)"></span>一般磚</span>
         <span class="item"><span class="box" style="background:#888"></span>不可破壞磚</span>
@@ -335,6 +349,7 @@ select optgroup { color: #0b1022; }
         <span class="item"><span class="box" style="background:var(--debuff)"></span>減益道具</span>
       </div>
     </div>
+  </div>
 
     <!-- 覆蓋層/畫廊/勝利/結束/提示 -->
     <div class="overlay">
@@ -952,14 +967,9 @@ select optgroup { color: #0b1022; }
   const promptQueue=[];
   function showPrompt(text){
     if(!promptsDock) return;
-    const L = layout();
-    const w = brickW*4 + L.pad*3;
-    const h = brickH*4 + L.pad*3;
     const div=document.createElement('div');
     div.className='prompt';
     div.textContent=text;
-    div.style.width=w+'px';
-    div.style.height=h+'px';
     promptsDock.appendChild(div);
     promptQueue.push(div);
     while(promptQueue.length>3){ const old=promptQueue.shift(); old.remove(); }


### PR DESCRIPTION
## Summary
- Keep HUD and game board spacing stable by wrapping prompts and stage in a new play area container
- Position short prompt cards responsively: row above the board on mobile and vertical stack beside it on desktop
- Simplify prompt creation by removing JS-driven sizing

## Testing
- `node --check skin.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5e93b27e48328a51b992e28f0ee6d