### PR TITLE
Fix mobile buff card clipping

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,6 +299,7 @@ select optgroup { color: #0b1022; }
   .stage #fx { inset: 8px; border-radius: 18px; }
   canvas#game { border-radius: 18px; }
   .legend { transform: scale(0.92); transform-origin: top center; }
+  #buffs { transform: scale(0.9); transform-origin: top center; }
 }
 /* Tighten stage inner gap so LED touches the border visually (no空隙) */
 .stage { --stage-inset: 8px; } /* keep a var if future skins need it */


### PR DESCRIPTION
## Summary
- scale buff card row on small screens to keep edge badges fully visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b680ed91c483289a8ad5e0fc09b2ec