### PR TITLE
Fix prompt card width and start countdown after closing note

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,8 +111,8 @@
       overflow:hidden;
     }
     #promptsDock .prompt{
-      flex:0 0 calc(33.333% - 8px);
-      max-width:33.333%;
+      flex:0 0 calc(33.333% - 12px);
+      max-width:calc(33.333% - 12px);
       min-width:0;height:48px;
       padding:8px 10px;border:1px solid var(--stroke);border-radius:12px;
       background:linear-gradient(180deg,var(--glass-1),var(--glass-2));
@@ -646,7 +646,7 @@ select optgroup { color: #0b1022; }
 
   function menusOpen(){
     return !!document.querySelector('#soundMenu.show, #optMenu.show') ||
-           (galleryPage && galleryPage.style.display !== 'none');
+           (galleryPage && galleryPage.style.display && galleryPage.style.display !== 'none');
   }
 
   // 關閉視窗按鈕（關閉後立即倒數、繼續遊戲）


### PR DESCRIPTION
## Summary
- Prevent prompt cards from being clipped at screen edges
- Ensure closing the start note triggers the 3-2-1 countdown

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b68eadc2188328b377baadf0b448ba