### PR TITLE
Fix countdown restart loop at game start

### DIFF
--- a/index.html
+++ b/index.html
@@ -2457,7 +2457,7 @@ function generateLevel(lv, L){
     const tick=()=>{
       if(countdownShow<=0){ resumePending=false; paused=false; stats.lifeStart=performance.now(); return; }
       beep(600 + (3-countdownShow)*100, 0.07, 0.05);
-      setTimeout(()=>{ countdownShow--; if(countdownShow===0){ paused=false; } else { tick(); } }, 450);
+      setTimeout(()=>{ countdownShow--; tick(); }, 450);
     };
     tick();
   }


### PR DESCRIPTION
## Summary
- Ensure start countdown tick always completes, resetting `resumePending` and starting play once

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b16fdfac8328a11e26cbc632d44e