### PR TITLE
Fix countdown loop on game start

### DIFF
--- a/index.html
+++ b/index.html
@@ -645,8 +645,10 @@ select optgroup { color: #0b1022; }
 
 
   function menusOpen(){
-    return !!document.querySelector('#soundMenu.show, #optMenu.show') ||
-           (galleryPage && galleryPage.style.display && galleryPage.style.display !== 'none');
+    return !!(
+      document.querySelector('#soundMenu.show, #optMenu.show') ||
+      (galleryPage && galleryPage.style.display && galleryPage.style.display !== 'none')
+    );
   }
 
   // 關閉視窗按鈕（關閉後立即倒數、繼續遊戲）


### PR DESCRIPTION
## Summary
- ensure `menusOpen` always returns a boolean to stop endless 3-2-1 countdowns

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b4d6e2f08328bcd08dd685bc2cc7