### PR TITLE
fix: prevent prompt cards from clipping on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,8 +111,8 @@
       overflow:hidden;
     }
     #promptsDock .prompt{
-      flex:0 0 calc(33.333% - 12px);
-      max-width:calc(33.333% - 12px);
+      flex:1 1 calc((100% - 16px)/3);
+      max-width:calc((100% - 16px)/3);
       min-width:0;height:48px;
       padding:8px 10px;border:1px solid var(--stroke);border-radius:12px;
       background:linear-gradient(180deg,var(--glass-1),var(--glass-2));


### PR DESCRIPTION
## Summary
- adjust prompt card flex sizing so three cards fit within viewport

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ba1983b4832883edde8ba9c35cd4