### PR TITLE
feat: add fire-themed skin

### DIFF
--- a/index.html
+++ b/index.html
@@ -271,6 +271,25 @@ select optgroup { color: #0b1022; }
     body[data-skin="冰雪．極光絲綢"] .hearts .life-icon{ width:24px; height:24px; }
     body[data-skin="冰雪．極光絲綢"] .hearts .life-icon svg{ width:24px; height:24px; }
 
+    /* === 火焰．鳳羽流光 === */
+    body[data-skin="火焰．鳳羽流光"]{
+      --ink:#fff5f2;
+      --muted:#ffcbb8;
+      --stroke:rgba(255,140,120,.38);
+      --bg1:#2a0b0b;
+      --bg2:#120202;
+      --hudGrad1:rgba(90,20,0,.60);
+      --hudGrad2:rgba(50,10,0,.44);
+      --glass-1:rgba(255,120,60,.12);
+      --glass-2:rgba(255,80,30,.09);
+      --stageGlass:linear-gradient(180deg, rgba(255,110,30,.05), transparent);
+      --panelPattern:radial-gradient(140px 100px at 80% 20%, rgba(255,80,20,.08), transparent 60%), radial-gradient(120px 80px at 20% 80%, rgba(255,160,60,.06), transparent 60%);
+      --btnGlow:0 0 22px rgba(255,100,60,.28);
+    }
+    body[data-skin="火焰．鳳羽流光"] .stage::before{
+      background: conic-gradient(from 0deg, #ff4500, #ffae00, #ffe680, #ffae00, #ff4500);
+    }
+
 
 /* === 霓虹 LED 燈條（與 index_skin.html 一致的六色流光） === */
 .stage::before{

--- a/skin.js
+++ b/skin.js
@@ -120,6 +120,30 @@
         bg: ['#0b1626', '#0a1a2f', '#081628']
       },
       desc: '極光絲緞：冰藍呼吸＋輕雪＋低對比極光束；2.2s。'
+    },
+
+    firePhoenix: {
+      label: '火焰．鳳羽流光',
+      selectLabel: '火焰．鳳羽流光',
+      cssSkin: '火焰．鳳羽流光',
+      lifeIcon: '🔥',
+      cssVars: {
+        '--fxViz': '1',
+        '--panelPattern':
+          'radial-gradient(140px 100px at 80% 20%, rgba(255,80,20,.08), transparent 60%), radial-gradient(120px 80px at 20% 80%, rgba(255,160,60,.06), transparent 60%)'
+      },
+      canvas: {
+        base: [255, 90, 20],
+        hi: [255, 240, 200],
+        period: 1800,
+        effects: {
+          embers: { count: 220, omega: 0.0023, center: [0.5, 0.6] },
+          prism: { beams: 8, speed: 0.0005, alpha: 0.08, spread: 0.8, hueShift: 20 },
+          diffuse: {}
+        },
+        bg: ['#2a0b0b', '#1a0703', '#100201']
+      },
+      desc: '鳳羽流光：暖橘呼吸＋旋渦炭火與金色光束，1.8s 呼吸。'
     }
   };
 


### PR DESCRIPTION
## Summary
- add "火焰．鳳羽流光" skin with custom LED pattern and fiery background effects
- introduce Korean-inspired HUD and button colors with ember and prism canvas effects

## Testing
- `node --check skin.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c4cf46d4832892614cf7cf4cf08a