### PR TITLE
refactor: redesign fire skin with solar flair

### DIFF
--- a/index.html
+++ b/index.html
@@ -271,23 +271,23 @@ select optgroup { color: #0b1022; }
     body[data-skin="冰雪．極光絲綢"] .hearts .life-icon{ width:24px; height:24px; }
     body[data-skin="冰雪．極光絲綢"] .hearts .life-icon svg{ width:24px; height:24px; }
 
-    /* === 火焰．鳳羽流光 === */
-    body[data-skin="火焰．鳳羽流光"]{
-      --ink:#fff5f2;
-      --muted:#ffcbb8;
-      --stroke:rgba(255,140,120,.38);
-      --bg1:#2a0b0b;
-      --bg2:#120202;
-      --hudGrad1:rgba(90,20,0,.60);
-      --hudGrad2:rgba(50,10,0,.44);
-      --glass-1:rgba(255,120,60,.12);
-      --glass-2:rgba(255,80,30,.09);
-      --stageGlass:linear-gradient(180deg, rgba(255,110,30,.05), transparent);
-      --panelPattern:radial-gradient(140px 100px at 80% 20%, rgba(255,80,20,.08), transparent 60%), radial-gradient(120px 80px at 20% 80%, rgba(255,160,60,.06), transparent 60%);
-      --btnGlow:0 0 22px rgba(255,100,60,.28);
+    /* === 烈陽．炙金幻焰 === */
+    body[data-skin="烈陽．炙金幻焰"]{
+      --ink:#fff6e8;
+      --muted:#ffd3a6;
+      --stroke:rgba(255,180,120,.36);
+      --bg1:#3a1000;
+      --bg2:#1a0400;
+      --hudGrad1:rgba(90,30,0,.58);
+      --hudGrad2:rgba(60,20,0,.44);
+      --glass-1:rgba(255,170,80,.12);
+      --glass-2:rgba(255,130,40,.09);
+      --stageGlass:linear-gradient(180deg, rgba(255,160,40,.05), transparent);
+      --panelPattern:radial-gradient(150px 110px at 80% 20%, rgba(255,170,40,.08), transparent 60%), radial-gradient(130px 90px at 20% 80%, rgba(255,120,30,.06), transparent 60%);
+      --btnGlow:0 0 22px rgba(255,160,80,.28);
     }
-    body[data-skin="火焰．鳳羽流光"] .stage::before{
-      background: conic-gradient(from 0deg, #ff4500, #ffae00, #ffe680, #ffae00, #ff4500);
+    body[data-skin="烈陽．炙金幻焰"] .stage::before{
+      background: conic-gradient(from 0deg, #ff8800, #ffd34d, #fff2b6, #ffd34d, #ff8800);
     }
 
 

--- a/skin.js
+++ b/skin.js
@@ -122,28 +122,29 @@
       desc: '極光絲緞：冰藍呼吸＋輕雪＋低對比極光束；2.2s。'
     },
 
-    firePhoenix: {
-      label: '火焰．鳳羽流光',
-      selectLabel: '火焰．鳳羽流光',
-      cssSkin: '火焰．鳳羽流光',
-      lifeIcon: '🔥',
+    solarFlare: {
+      label: '烈陽．炙金幻焰',
+      selectLabel: '烈陽．炙金幻焰',
+      cssSkin: '烈陽．炙金幻焰',
+      lifeIcon: '☀️',
       cssVars: {
         '--fxViz': '1',
         '--panelPattern':
-          'radial-gradient(140px 100px at 80% 20%, rgba(255,80,20,.08), transparent 60%), radial-gradient(120px 80px at 20% 80%, rgba(255,160,60,.06), transparent 60%)'
+          'radial-gradient(150px 110px at 80% 20%, rgba(255,170,40,.08), transparent 60%), radial-gradient(130px 90px at 20% 80%, rgba(255,120,30,.06), transparent 60%)'
       },
       canvas: {
-        base: [255, 90, 20],
-        hi: [255, 240, 200],
-        period: 1800,
+        base: [255, 140, 40],
+        hi: [255, 255, 240],
+        period: 2000,
         effects: {
-          embers: { count: 220, omega: 0.0023, center: [0.5, 0.6] },
-          prism: { beams: 8, speed: 0.0005, alpha: 0.08, spread: 0.8, hueShift: 20 },
-          diffuse: {}
+          embers: { count: 200, omega: 0.0018, center: [0.5, 0.55] },
+          sparks: { count: 80 },
+          prism: { beams: 10, speed: 0.0004, alpha: 0.08, spread: 0.78, hueShift: 24 },
+          pulse: { color: [255, 180, 60], thickness: 6, intervalMul: 1.1 }
         },
-        bg: ['#2a0b0b', '#1a0703', '#100201']
+        bg: ['#3a1000', '#200600', '#120200']
       },
-      desc: '鳳羽流光：暖橘呼吸＋旋渦炭火與金色光束，1.8s 呼吸。'
+      desc: '炙金幻焰：金橙呼吸＋旋轉熾燼與脈衝光束，2s 週期。'
     }
   };
 


### PR DESCRIPTION
## Summary
- replace flame skin with newly designed "烈陽．炙金幻焰" theme
- refresh canvas effects and CSS variables for warmer golden palette

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c8c5bd0083288aa7069c12131578