### PR TITLE
Remove neon overlay from stage

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,40 +286,8 @@ select optgroup { color: #0b1022; }
       --panelPattern:none;
       --btnGlow:0 0 22px rgba(255,160,80,.28);
     }
-    body[data-skin="烈陽．炙金幻焰"] .stage::before{
-      background: conic-gradient(
-        from 0deg,
-        rgba(255,215,150,0) 0deg,
-        rgba(255,215,150,0.55) 90deg,
-        rgba(255,235,185,0.6) 180deg,
-        rgba(255,215,150,0.55) 270deg,
-        rgba(255,215,150,0) 360deg
-      );
-    }
 
 
-/* === 霓虹 LED 燈條（與 index_skin.html 一致的六色流光） === */
-.stage::before{
-  content:""; position:absolute; inset:var(--stage-inset); border-radius:18px; pointer-events:none;
-  opacity: calc(var(--fxViz) * .9);
-  background: conic-gradient(
-    from 0deg,
-    rgba(255,0,102,.0) 0deg,
-    rgba(255,0,102,.32) 20deg,
-    rgba(255,204,0,.26) 60deg,
-    rgba(0,200,255,.28) 120deg,
-    rgba(160,80,255,.28) 180deg,
-    rgba(0,255,200,.26) 240deg,
-    rgba(255,0,102,.32) 300deg,
-    rgba(255,0,102,.0) 360deg
-  );
-  -webkit-mask: radial-gradient(closest-side, transparent  calc(100% - 3px), black calc(100% - 2px));
-          mask: radial-gradient(closest-side, transparent  calc(100% - 3px), black calc(100% - 2px));
-  box-shadow: 0 0 40px rgba(0,200,255,.25), inset 0 0 22px rgba(255,255,255,.08);
-  filter: hue-rotate(0deg);
-  animation: neon-hue 8s linear infinite;
-}
-@keyframes neon-hue{ to{ filter: hue-rotate(360deg); } }
 
 /* HUD/按鍵的霓虹語彙（按鍵邊緣流光＋心形光暈） */
 
@@ -333,8 +301,6 @@ select optgroup { color: #0b1022; }
   .legend { transform: scale(0.92); transform-origin: top center; }
   #buffs { --buff-scale: 0.9; }
 }
-/* Tighten stage inner gap so LED touches the border visually (no空隙) */
-.stage { --stage-inset: 8px; } /* keep a var if future skins need it */
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- drop `.stage::before` pseudo-element and its animation to eliminate large translucent overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d9ffdb788328b51226bf286aea6a