### PR TITLE
feat: adjust solar flare sun visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -3293,16 +3293,22 @@ function boot(){
     ctx.save();
     ctx.translate(cx,cy);
     ctx.rotate(rot);
-    ctx.globalAlpha=opt.alpha||0.6;
+    ctx.globalAlpha=opt.alpha||0.4;
 
     const rayCount=opt.rayCount||20;
     const inner=r*0.6;
-    const outer=r;
-    ctx.fillStyle='rgba(255,200,80,0.5)';
+    const outerLong=r;
+    const outerShort=r*0.8;
+    ctx.fillStyle='rgba(255,200,80,0.35)';
     ctx.beginPath();
     for(let i=0;i<rayCount*2;i++){
       const ang=i*Math.PI/rayCount;
-      const rad=i%2===0?outer:inner;
+      let rad;
+      if(i%2===0){
+        rad = i%4===0?outerLong:outerShort;
+      }else{
+        rad = inner;
+      }
       const x=Math.cos(ang)*rad;
       const y=Math.sin(ang)*rad;
       if(i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y);
@@ -3311,8 +3317,9 @@ function boot(){
     ctx.fill();
 
     const g=ctx.createRadialGradient(0,0,0,0,0,inner);
-    g.addColorStop(0,'rgba(255,245,210,0.9)');
-    g.addColorStop(1,'rgba(255,200,80,0)');
+    g.addColorStop(0,'rgba(255,255,220,0.9)');
+    g.addColorStop(0.7,'rgba(255,180,40,0.4)');
+    g.addColorStop(1,'rgba(255,140,0,0)');
     ctx.fillStyle=g;
     ctx.beginPath();
     ctx.arc(0,0,inner,0,Math.PI*2);

--- a/skin.js
+++ b/skin.js
@@ -135,12 +135,12 @@
           effects: {
             flames: { count: 60, baseY: 0.82, sizeMin: 3, sizeMax: 8, speedMin: 0.25, speedMax: 0.6 },
             sun: {
-              rotationPeriodMs: 30000,
+              rotationPeriodMs: 60000,
               scalePeriodMs: 120000,
               sizeMin: 0.05,
               sizeMax: 0.3,
-              centerY: 0.55,
-              alpha: 0.6
+              centerY: 0.6,
+              alpha: 0.4
             }
           },
           bg: ['#3a1000', '#200600', '#120200']


### PR DESCRIPTION
## Summary
- slow solar flare sun rotation, lower placement, and increased transparency
- add alternating ray heights and stronger color gradient for sun effect

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f4d5ac0c8328bda8109462b017e6