### PR TITLE
feat: refresh spider silk trap skin

### DIFF
--- a/index.html
+++ b/index.html
@@ -289,21 +289,30 @@ select optgroup { color: #0b1022; }
 
     /* === 蜘蛛．銀絲陷阱 === */
     body[data-skin="蜘蛛．銀絲陷阱"]{
-      --ink:#f5f5f5;
-      --muted:#d5d5d5;
-      --stroke:rgba(220,220,230,.34);
+      --ink:#000000;
+      --muted:#444444;
+      --stroke:rgba(0,0,0,.85);
       --bg1:#1a1a1a;
       --bg2:#000000;
-      --hudGrad1:rgba(240,240,245,.60);
-      --hudGrad2:rgba(220,220,230,.44);
-      --glass-1:rgba(255,255,255,.14);
-      --glass-2:rgba(255,255,255,.10);
-      --stageGlass:linear-gradient(180deg, rgba(255,255,255,.04), transparent);
-      --panelPattern:repeating-radial-gradient(circle at 50% 50%, rgba(255,255,255,.08) 0 1px, transparent 1px 12px),repeating-conic-gradient(rgba(255,255,255,.04) 0deg 10deg, transparent 10deg 20deg);
-      --btnGlow:0 0 20px rgba(220,220,240,.26);
+      --hudGrad1:#ffffff;
+      --hudGrad2:#ffffff;
+      --glass-1:#ffffff;
+      --glass-2:#ffffff;
+      --stageGlass:linear-gradient(180deg, rgba(0,0,0,.02), transparent);
+      --panelPattern:none;
+      --btnGlow:0 0 20px rgba(0,0,0,.26);
     }
-
-
+    body[data-skin="蜘蛛．銀絲陷阱"] .hud,
+    body[data-skin="蜘蛛．銀絲陷阱"] .pill,
+    body[data-skin="蜘蛛．銀絲陷阱"] .ic-btn,
+    body[data-skin="蜘蛛．銀絲陷阱"] .btn,
+    body[data-skin="蜘蛛．銀絲陷阱"] #buffs .badge,
+    body[data-skin="蜘蛛．銀絲陷阱"] #promptsDock .prompt{
+      background:#ffffff;
+      color:#000000;
+      border-color:#000000;
+    }
+    body[data-skin="蜘蛛．銀絲陷阱"] .ic-btn .ico{color:#000000;}
 
 /* HUD/按鍵的霓虹語彙（按鍵邊緣流光＋心形光暈） */
 
@@ -3305,7 +3314,8 @@ function boot(){
     const phase = (time % period) / period;
     const rMax = Math.hypot(w,h)*0.6;
     const r = phase * rMax;
-    const shimmer = 0.5 + 0.5*Math.sin(time*0.0004);
+    const flash = Math.pow(Math.sin(time*0.0002), 8);
+    const shimmer = 0.1 + 0.9*flash;
     const alpha = (opt.alpha || 0.05) * shimmer * (1 - phase);
     ctx.save();
     ctx.translate(w/2, h/2);

--- a/skin.js
+++ b/skin.js
@@ -155,7 +155,7 @@
         lifeIcon: '🕷️',
         cssVars: {
           '--fxViz': '0',
-          '--panelPattern': 'repeating-radial-gradient(circle at 50% 50%, rgba(255,255,255,0.08) 0 1px, transparent 1px 12px),repeating-conic-gradient(rgba(255,255,255,0.04) 0deg 10deg, transparent 10deg 20deg)'
+          '--panelPattern': 'none'
         },
         canvas: {
           base: [210, 210, 210],
@@ -163,11 +163,11 @@
           period: 3200,
           effects: {
             ledStrip: { lo: [60, 60, 60], hi: [240, 240, 240], period: 3200 },
-            web: { period: 30000, alpha: 0.05 }
+            web: { period: 30000, alpha: 0.02 }
           },
           bg: ['#1a1a1a', '#0f0f0f', '#000000']
         },
-        desc: '銀絲陷阱：銀白 HUD 與慢速呼吸 LED；淡淡蛛網背景徐徐展開。'
+        desc: '銀絲陷阱：純白 HUD 與慢速呼吸 LED；蛛網特效緩慢展開。'
       }
     };
 


### PR DESCRIPTION
## Summary
- style HUD and buttons pure white with black outlines for Spider Silk Trap skin
- move cobweb from background to in-game effect with faint shimmer flashes
- update description for spider skin

## Testing
- `npm test` (fails: ENOENT no package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b818d7c2d08328ac9dc3e948587523