### PR TITLE
feat: add looping bgm variations

### DIFF
--- a/index.html
+++ b/index.html
@@ -1159,59 +1159,90 @@ select optgroup { color: #0b1022; }
 
   // === BGM 主題依關卡段落 ===
   function bgmThemeForLevel(lv){
-    if(lv<=5) return 'whimsy';       // 輕快奇妙
-    if(lv<=10) return 'knight';      // 中期戰鬥
-    if(lv<=15) return 'colossus';    // 巨人威壓
-    return 'demon';                  // 終章決戰
+    if(lv<=4) return 'picnic';      // 開心郊遊
+    if(lv===5) return 'lion';       // 獅子王決戰
+    if(lv<=9) return 'castle';      // 攻入城堡
+    if(lv===10) return 'duel';      // 騎士對決
+    if(lv<=14) return 'valley';     // 潛入巨人山谷
+    if(lv===15) return 'giant';     // 決戰巨人
+    if(lv<=19) return 'demon';      // 惡魔城
+    return 'finale';                // 最終魔王
   }
-  let currentBGMTheme = null;
+
+  // === BGM 變奏資料 ===
+  function midi(n){ return 440*Math.pow(2,(n-69)/12); }
+  const transposeSeq=(seq,s)=>seq.map(ch=>Array.isArray(ch)?ch.map(n=>n+s):n+s);
+  const rotateSeq=(arr,k)=>arr.slice(k).concat(arr.slice(0,k));
+
+  function buildTheme(tempo, chords, melody){
+    const play=(ch,mel,start,tone)=>{
+      const beat=60/tempo;
+      ch.forEach((c,i)=>c.forEach(n=>tone(midi(n),'triangle', start+i*4*beat, 3.8*beat, 0.04)));
+      mel.forEach((m,i)=>tone(midi(m),'sine', start+i*2*beat, 1.6*beat, 0.045));
+      for(let i=0;i<32;i++){ tone(100,'square', start+i*beat, 0.05*beat, 0.015); }
+      return 32*beat;
+    };
+    return {
+      tempo,
+      patterns:[
+        (t,tn)=>play(chords, melody, t, tn),
+        (t,tn)=>play(transposeSeq(chords,2), melody, t, tn),
+        (t,tn)=>play(chords, transposeSeq(melody,2), t, tn),
+        (t,tn)=>play(rotateSeq(chords,2), melody, t, tn)
+      ]
+    };
+  }
+
+  const BGM_PATTERNS={
+    picnic: buildTheme(100,
+      [[60,64,67],[65,69,72],[67,71,74],[60,64,67],[57,60,64],[62,65,69],[67,71,74],[60,64,67]],
+      [72,74,76,79,76,74,72,69,72,74,76,74,72,69,67,69]),
+    lion: buildTheme(120,
+      [[62,65,69],[58,62,65],[60,64,67],[62,65,69],[65,69,72],[60,64,67],[62,65,69],[57,62,65]],
+      [74,74,76,74,72,71,72,74,76,74,72,69,67,69,71,72]),
+    castle: buildTheme(90,
+      [[64,67,71],[60,64,67],[62,65,69],[59,62,67],[64,67,71],[60,64,67],[62,65,69],[64,67,71]],
+      [76,74,72,71,72,74,76,78,76,74,72,71,69,71,72,74]),
+    duel: buildTheme(110,
+      [[67,71,74],[64,67,71],[60,64,67],[62,65,69],[67,71,74],[60,64,67],[57,60,64],[62,65,69]],
+      [79,76,74,72,74,76,79,81,79,76,74,72,74,76,77,79]),
+    valley: buildTheme(100,
+      [[69,73,76],[66,69,73],[62,66,69],[64,69,72],[69,73,76],[64,69,72],[62,66,69],[59,62,66]],
+      [81,78,76,74,76,78,81,83,81,78,76,74,76,78,79,81]),
+    giant: buildTheme(80,
+      [[65,68,72],[63,66,70],[60,63,67],[58,61,65],[65,68,72],[60,63,67],[63,66,70],[65,68,72]],
+      [77,75,72,70,72,75,77,79,77,75,72,70,72,75,77,79]),
+    demon: buildTheme(140,
+      [[71,74,78],[67,71,74],[69,72,76],[65,69,72],[71,74,78],[67,71,74],[69,72,76],[71,74,78]],
+      [83,81,78,76,78,81,83,85,83,81,78,76,78,81,83,85]),
+    finale: buildTheme(150,
+      [[60,63,67],[65,68,72],[70,74,77],[65,68,72],[60,63,67],[65,68,72],[70,74,77],[72,75,79]],
+      [72,75,77,79,77,75,72,70,72,75,77,75,72,70,68,70])
+  };
+
+  let currentBGMTheme=null;
   function startBGMTheme(theme){
     if(!audioCtx) ensureAudio();
     if(!audioCtx || !bgmOn) return;
     stopBGM();
     bgmStarted=true;
-    currentBGMTheme = theme;
-    const now=audioCtx.currentTime;
-    function tone(freq, type, start, dur, gain=0.045){
-      const o=audioCtx.createOscillator(); const g=audioCtx.createGain();
+    currentBGMTheme=theme;
+    let variant=0;
+    function tone(freq,type,start,dur,gain=0.045){
+      const o=audioCtx.createOscillator();
+      const g=audioCtx.createGain();
       o.type=type; o.frequency.value=freq; g.gain.value=0; o.connect(g); g.connect(bgmGain);
-      o.start(now+start); g.gain.setTargetAtTime(gain, now+start, 0.015);
-      g.gain.setTargetAtTime(0.0001, now+start+dur-0.03, 0.02);
-      o.stop(now+start+dur+0.1); bgmNodes.push(o,g);
+      o.start(start); g.gain.setTargetAtTime(gain,start,0.015);
+      g.gain.setTargetAtTime(0.0001,start+dur-0.03,0.02);
+      o.stop(start+dur+0.1); bgmNodes.push(o,g);
     }
     function scheduleLoop(){
       if(!bgmOn || !bgmStarted) return;
-      const base=audioCtx.currentTime;
-      bgmNodes=[];
-      if(theme==='whimsy'){
-        const tempo=96/60;
-        const chords=[[261.63,329.63,392.00],[293.66,349.23,440.00],[329.63,392.00,493.88],[293.66,392.00,523.25]];
-        for(let i=0;i<4;i++){ for(const f of chords[i]) tone(f,'triangle', i*2/tempo, 1.8/tempo, 0.035); }
-        const mel=[659.25,698.46,783.99,880.00,783.99,698.46,659.25,587.33];
-        mel.forEach((f,idx)=> tone(f,'sine', idx*0.4/tempo, 0.28/tempo, 0.045));
-        setTimeout(scheduleLoop, 3200);
-      }else if(theme==='knight'){
-        const tempo=128/60;
-        const riff=[196.00,246.94,293.66,246.94,196.00,220.00,246.94,220.00];
-        riff.forEach((f,idx)=> tone(f,'sawtooth', idx*0.25/tempo, 0.22/tempo, 0.055));
-        const stab=[392.00,392.00,349.23,440.00];
-        stab.forEach((f,idx)=> tone(f,'square', 1.2 + idx*0.5/tempo, 0.3/tempo, 0.065));
-        setTimeout(scheduleLoop, 3000);
-      }else if(theme==='colossus'){
-        const tempo=72/60;
-        const bass=[98.00,87.31,82.41,73.42];
-        bass.forEach((f,idx)=> tone(f,'sine', idx*1.5/tempo, 1.2/tempo, 0.06));
-        const hit=[196.00,174.61,196.00];
-        hit.forEach((f,idx)=> tone(f,'square', 0.9 + idx*0.7/tempo, 0.2/tempo, 0.05));
-        setTimeout(scheduleLoop, 4200);
-      }else{ // demon
-        const tempo=140/60;
-        const ost=[293.66,277.18,261.63,246.94,233.08,246.94,261.63,277.18];
-        ost.forEach((f,idx)=> tone(f,'sawtooth', idx*0.22/tempo, 0.2/tempo, 0.04));
-        const stab=[587.33,554.37,523.25,493.88];
-        stab.forEach((f,idx)=> tone(f,'square', 1.3 + idx*0.4/tempo, 0.22/tempo, 0.05));
-        setTimeout(scheduleLoop, 2800);
-      }
+      const data=BGM_PATTERNS[theme];
+      const base=audioCtx.currentTime+0.05;
+      const loopDur=data.patterns[variant](base, tone);
+      variant=(variant+1)%data.patterns.length;
+      setTimeout(scheduleLoop, loopDur*1000-100);
     }
     scheduleLoop();
   }


### PR DESCRIPTION
## Summary
- redesign BGM system with themes for each level range
- add four-variation loops per theme to keep music lively

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b85d208f3c8328a44ef0739bd72640