### PR TITLE
Track and clear BGM theme timer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1222,9 +1222,12 @@ select optgroup { color: #0b1022; }
   };
 
   let currentBGMTheme=null;
+  let bgmTimer=null;
   function startBGMTheme(theme){
     if(!audioCtx) ensureAudio();
     if(!audioCtx || !bgmOn) return;
+    clearTimeout(bgmTimer);
+    bgmTimer=null;
     stopBGM();
     bgmStarted=true;
     currentBGMTheme=theme;
@@ -1246,7 +1249,7 @@ select optgroup { color: #0b1022; }
       const base=audioCtx.currentTime+0.05;
       const loopDur=data.patterns[variant](base, tone);
       variant=(variant+1)%data.patterns.length;
-      setTimeout(scheduleLoop, loopDur*1000-100);
+      bgmTimer=setTimeout(scheduleLoop, loopDur*1000-100);
     }
     scheduleLoop();
   }
@@ -1355,6 +1358,8 @@ select optgroup { color: #0b1022; }
     if(!audioCtx || bgmStarted) return; audioCtx.resume?.(); bgmStarted=true; applyBGMThemeForLevel();
   }
   function stopBGM(){
+    clearTimeout(bgmTimer);
+    bgmTimer=null;
     bgmStarted=false;
     bgmNodes.forEach(n=>{try{n.disconnect?.();}catch{}});
     bgmNodes.clear();


### PR DESCRIPTION
## Summary
- keep a `bgmTimer` handle for looping background music
- clear any pending BGM timers when switching themes or stopping music

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b866c9a0488328a895ac7ec345efc1