### PR TITLE
feat: refine steam knight gear background

### DIFF
--- a/index.html
+++ b/index.html
@@ -3597,7 +3597,9 @@ function boot(){
       for(let i=0;i<eff.gears.count;i++){
         const r=(eff.gears.sizeMin||40)+Math.random()*((eff.gears.sizeMax||100)-(eff.gears.sizeMin||40));
         const speed=(eff.gears.speedMin||0.0005)+Math.random()*((eff.gears.speedMax||0.0015)-(eff.gears.speedMin||0.0005));
-        gears.push({x:Math.random()*w,y:Math.random()*h,r,teeth:8+Math.floor(Math.random()*5),rot:Math.random()*Math.PI*2,speed});
+        const x=Math.random()*w;
+        const y=h*0.55 + Math.random()*h*0.45; // avoid upper brick area
+        gears.push({x,y,r,teeth:8+Math.floor(Math.random()*5),rot:Math.random()*Math.PI*2,speed});
       }
     }
     if(eff.sun) sunOpt=eff.sun;
@@ -3763,7 +3765,39 @@ function boot(){
       if(clouds.length){ctx.globalAlpha=eff.clouds.alpha||0.15;for(const c of clouds){c.x+=Math.sin(t*0.00005+c.ph)*(eff.clouds.speed||0.002)*50; if(c.x>w+200)c.x=-200;ctx.beginPath();ctx.fillStyle='#ffffff';ctx.arc(c.x,c.y,c.sz,0,Math.PI*2);ctx.fill();}ctx.globalAlpha=1;}
       if(embers.length){const cx=w*(eff.embers.center?eff.embers.center[0]:0.5), cy=h*(eff.embers.center?eff.embers.center[1]:0.5);for(const p of embers){p.ph+=eff.embers.omega||0.002;const r=Math.hypot(p.x-cx,p.y-cy);const ang=Math.atan2(p.y-cy,p.x-cx)+ (eff.embers.omega||0.002);p.x=cx+Math.cos(ang)*r; p.y=cy+Math.sin(ang)*r; ctx.fillStyle='rgba(255,120,40,0.8)';ctx.beginPath();ctx.arc(p.x,p.y,2,0,Math.PI*2);ctx.fill();}}
       if(shards.length){ctx.strokeStyle='rgba(220,245,255,0.5)';ctx.lineWidth=1;for(const s of shards){s.x+=Math.cos(s.ang)*2; s.y+=Math.sin(s.ang)*2; if(s.x<-50||s.x>w+50||s.y<-50||s.y>h+50){s.x=Math.random()*w;s.y=-10;}ctx.beginPath();ctx.moveTo(s.x,s.y);ctx.lineTo(s.x+Math.cos(s.ang)*40,s.y+Math.sin(s.ang)*40);ctx.stroke();}}
-      if(gears.length){for(const g of gears){g.rot+=g.speed;ctx.save();ctx.translate(g.x,g.y);ctx.rotate(g.rot);ctx.beginPath();for(let i=0;i<g.teeth*2;i++){const ang=i*Math.PI/g.teeth;const rad=(i%2===0)?g.r:g.r*0.75;const x=Math.cos(ang)*rad;const y=Math.sin(ang)*rad;if(i===0)ctx.moveTo(x,y);else ctx.lineTo(x,y);}ctx.closePath();ctx.fillStyle='rgba(160,120,60,0.3)';ctx.fill();ctx.strokeStyle='rgba(255,220,150,0.5)';ctx.lineWidth=g.r*0.1;ctx.stroke();ctx.beginPath();ctx.arc(0,0,g.r*0.4,0,Math.PI*2);ctx.fillStyle='rgba(60,40,20,0.6)';ctx.fill();ctx.restore();}}
+      if(gears.length){
+        for(const g of gears){
+          g.rot+=g.speed;
+          ctx.save();
+          ctx.translate(g.x,g.y);
+          ctx.rotate(g.rot);
+          ctx.beginPath();
+          for(let i=0;i<g.teeth*2;i++){
+            const ang=i*Math.PI/g.teeth;
+            const rad=(i%2===0)?g.r:g.r*0.75;
+            const x=Math.cos(ang)*rad;
+            const y=Math.sin(ang)*rad;
+            if(i===0)ctx.moveTo(x,y);else ctx.lineTo(x,y);
+          }
+          ctx.closePath();
+          const grad=ctx.createRadialGradient(0,0,g.r*0.1,0,0,g.r);
+          grad.addColorStop(0,'rgba(255,255,255,0.25)');
+          grad.addColorStop(1,'rgba(160,120,60,0.05)');
+          ctx.fillStyle=grad;
+          ctx.fill();
+          ctx.strokeStyle='rgba(220,180,120,0.3)';
+          ctx.lineWidth=g.r*0.08;
+          ctx.stroke();
+          ctx.beginPath();
+          ctx.arc(0,0,g.r*0.4,0,Math.PI*2);
+          const hub=ctx.createRadialGradient(0,0,g.r*0.05,0,0,g.r*0.4);
+          hub.addColorStop(0,'rgba(80,60,40,0.4)');
+          hub.addColorStop(1,'rgba(60,40,20,0.2)');
+          ctx.fillStyle=hub;
+          ctx.fill();
+          ctx.restore();
+        }
+      }
       if(sparks.length){for(const sp of sparks){ctx.fillStyle='rgba(255,210,122,0.8)';ctx.fillRect(sp.x,sp.y,2,2);}}
       if(flames.length){for(const f of flames){f.y-=f.speed;f.x+=Math.sin(t*0.002+f.ph)*(flameOpt?.drift||0.3);f.alpha-=0.004;f.size*=0.98;if(f.alpha<=0||f.y<h*(flameOpt?.dieY||0.55)){f.x=Math.random()*w;f.y=h*(flameOpt?.baseY||0.8)+Math.random()*h*0.2;f.size=(flameOpt?.sizeMin||2)+Math.random()*((flameOpt?.sizeMax||6)-(flameOpt?.sizeMin||2));f.alpha=0.5+Math.random()*0.5;f.speed=(flameOpt?.speedMin||0.3)+Math.random()*((flameOpt?.speedMax||0.8)-(flameOpt?.speedMin||0.3));f.ph=Math.random()*Math.PI*2;}ctx.fillStyle=`rgba(255,220,150,${f.alpha})`;ctx.beginPath();ctx.arc(f.x,f.y,f.size,0,Math.PI*2);ctx.fill();}}
       if(sunOpt) drawSun(w,h,t,sunOpt);


### PR DESCRIPTION
## Summary
- adjust steam knight gear effect to render below brick area and reduce visual obstruction
- add metallic radial gradients and softer strokes for gears to improve quality and transparency

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe658ca9c8328ab9ad7dd758a6505