### PR TITLE
Display combo label with proper casing

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,8 +150,8 @@
       font-size:19px;
       font-family:'Playfair Display',serif;
       font-weight:700;
-      text-transform:lowercase;
-      font-variant-caps:small-caps;
+      text-transform:none;
+      font-variant-caps:normal;
       pointer-events:none;
       opacity:0;
       transform-origin:top right;


### PR DESCRIPTION
## Summary
- Remove small-caps styling so the combo label uses normal capitalization

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd494066ec8328854fd9ecd680bb02