### PR TITLE
Remove bunny-themed skin

### DIFF
--- a/index.html
+++ b/index.html
@@ -354,28 +354,6 @@ select optgroup { color: #0b1022; }
       --btnGlow:0 0 18px rgba(255,190,90,.25);
     }
 
-    /* === 兔兔·奶油雲朵 === */
-    body[data-skin="兔兔·奶油雲朵"]{
-      --ink:#d4a017;
-      --muted:#b88f3a;
-      --stroke:rgba(255,255,255,.9);
-      --bg1:#ffe4f2;
-      --bg2:#fff5fa;
-      --hudGrad1:rgba(255,240,245,.86);
-      --hudGrad2:rgba(255,225,235,.72);
-      --glass-1:rgba(255,255,255,.18);
-      --glass-2:rgba(255,213,232,.45);
-      --stageGlass:linear-gradient(180deg, rgba(255,240,245,.1), transparent);
-      --panelPattern:radial-gradient(80px 80px at 20% 20%, rgba(255,200,220,.2), transparent 60%),
-                      radial-gradient(60px 60px at 80% 30%, rgba(255,255,255,.15), transparent 40%);
-      --btnGlow:0 0 20px rgba(255,200,220,.4);
-    }
-
-    body[data-skin="兔兔·奶油雲朵"] canvas#game{position:relative;z-index:1;background:transparent;}
-    body[data-skin="兔兔·奶油雲朵"] .hearts .life-icon{width:32px;height:32px;}
-    body[data-skin="兔兔·奶油雲朵"] .hearts .life-icon svg{width:32px;height:32px;}
-    body[data-skin="兔兔·奶油雲朵"] .btn{background:#ffd5e8;color:#d4a017;border:2px solid #fff;}
-
 /* HUD/按鍵的霓虹語彙（按鍵邊緣流光＋心形光暈） */
 
 

--- a/skin.js
+++ b/skin.js
@@ -181,26 +181,8 @@
       bg: ['#3d2b1f', '#22160e', '#0e0b08']
     },
     desc: '銅黃齒輪搭深木板，齒輪鏈轉動；琥珀 LED 呼吸，工廠齒輪背景。'
-  },
-
-  bunnyCream: {
-    label: '兔兔·奶油雲朵',
-    selectLabel: '兔兔·奶油雲朵',
-    cssSkin: '兔兔·奶油雲朵',
-    lifeIcon: `<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg"><g fill="#fff" stroke="#e0e0e0" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="32" cy="40" rx="20" ry="16"/><ellipse cx="20" cy="18" rx="10" ry="20"/><ellipse cx="44" cy="18" rx="10" ry="20"/><circle cx="24" cy="36" r="6" fill="#000"/><circle cx="40" cy="36" r="6" fill="#000"/><circle cx="24" cy="34" r="2" fill="#fff"/><circle cx="40" cy="34" r="2" fill="#fff"/><circle cx="32" cy="44" r="3" fill="#ffb6c1"/><path d="M28 48Q32 52 36 48" stroke="#000" fill="none"/></g></svg>`,
-    canvas: {
-      base: [255, 240, 220],
-      hi: [255, 255, 255],
-      period: 3000,
-      effects: {
-        clouds: { count: 8, sizePx: 180, speed: 0.002, alpha: 0.25 },
-        balloons: { intervalMs: 10000, lifeMs: 40000, colors: ['#ff8aa0','#ffd966','#9ad0f5','#cfa0ff','#ffe599'] },
-        ledStrip: { hi: [255,255,255], lo: [255,240,200], period: 3000 }
-      },
-      bg: ['#aee1ff', '#fdfbff', '#ffffff']
-    },
-    desc: '童話兔兔：奶油 HUD、草莓蛋糕按鈕、柔黃白 LED，棉花雲與氣球飄浮，3s 週期。'
   }
+
 };
 
   // 對外暴露


### PR DESCRIPTION
## Summary
- remove bunny-themed "兔兔·奶油雲朵" skin from SKINS list
- drop corresponding CSS rules from index.html

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bda7fe47ac832895ce12d4dce982ea