### PR TITLE
Avoid preflight CORS error when uploading scores

### DIFF
--- a/index.html
+++ b/index.html
@@ -762,7 +762,11 @@ select optgroup { color: #0b1022; }
       longestSurvival: stats.longestLife
     };
     try{
-      await fetch(RANK_API,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
+      await fetch(RANK_API, {
+        method: 'POST',
+        headers: {'Content-Type': 'text/plain;charset=utf-8'},
+        body: JSON.stringify(payload)
+      });
       alert('上傳成功');
     }catch(e){
       alert('上傳失敗');


### PR DESCRIPTION
## Summary
- send leaderboard submissions as text/plain to skip CORS preflight

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc8da552883288c7d9fa9626e0d4d