### PR TITLE
Handle leaderboard loading errors and document API script

### DIFF
--- a/index.html
+++ b/index.html
@@ -718,7 +718,12 @@ select optgroup { color: #0b1022; }
   async function fetchLeaderboard(){
     const res = await fetch(RANK_API, {cache:'no-store'});
     if(!res.ok) throw new Error('fetch failed');
-    return await res.json();
+    const text = await res.text();
+    try{
+      return JSON.parse(text);
+    }catch(err){
+      throw new Error('invalid json');
+    }
   }
   function renderLeaderboard(data){
     rankTableBody.innerHTML='';

--- a/leaderboard.gs
+++ b/leaderboard.gs
@@ -1,0 +1,31 @@
+const SHEET_NAME = 'Leaderboard';
+const MAX_ROWS = 20;
+
+function doPost(e) {
+  const data  = JSON.parse(e.postData.contents);
+  const sheet = SpreadsheetApp.getActive().getSheetByName(SHEET_NAME);
+
+  sheet.appendRow([
+    new Date(), data.name, data.score, data.lives, data.catches,
+    data.powerUps, data.powerDowns, data.enemiesKilled,
+    data.bossKilled, data.fastestDeath, data.longestSurvival
+  ]);
+
+  sheet.sort({column: 3, ascending: false});
+  const lastRow = sheet.getLastRow();
+  if (lastRow > MAX_ROWS + 1) {
+    sheet.deleteRows(MAX_ROWS + 2, lastRow - (MAX_ROWS + 1));
+  }
+  // Apps Script automatically sets CORS headers for web apps.
+  return ContentService.createTextOutput('OK');
+}
+
+function doGet(e) {
+  const sheet    = SpreadsheetApp.getActive().getSheetByName(SHEET_NAME);
+  const rowCount = sheet.getLastRow() - 1;
+  const data     = rowCount > 0
+      ? sheet.getRange(2, 1, Math.min(rowCount, MAX_ROWS), sheet.getLastColumn()).getValues()
+      : [];
+  return ContentService.createTextOutput(JSON.stringify(data))
+      .setMimeType(ContentService.MimeType.JSON);
+}


### PR DESCRIPTION
## Summary
- Parse leaderboard API responses defensively to avoid crashes on invalid JSON
- Add Google Apps Script reference for storing and serving leaderboard data without unsupported headers

## Testing
- ⚠️ `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1ec954608328b7ccaf5cc541ba1d