### PR TITLE
fix: load leaderboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -557,7 +557,8 @@ select optgroup { color: #0b1022; }
 (() => {
 
   const RANK_API = 'https://script.google.com/macros/s/AKfycbxfonXG50htMNtP-XNBzkq5Sf8jUG3qzXfLRxJygP0xJIv0ifwvM8V63WpGt4gJ4Vtd/exec';
-  const CORS = (url) => 'https://corsproxy.io/?' + encodeURIComponent(url);
+  // 後端已支援 CORS，直接回傳原始 URL
+  const CORS = (url) => url;
   // === 設定 ===
   const GAME_CONFIG = {
     totalLevels: 20,

--- a/leaderboard.gs
+++ b/leaderboard.gs
@@ -2,10 +2,13 @@ const SHEET_NAME = 'Leaderboard';
 const MAX_ROWS = 20;  // 只顯示前 20 名，不刪除資料
 
 function setCors(output) {
-  output.setHeader('Access-Control-Allow-Origin', '*');
-  output.setHeader('Access-Control-Allow-Methods', 'GET, POST');
-  output.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-  output.setHeader('Cache-Control', 'no-store');
+  // Apps Script 的 TextOutput 沒有 setHeader，需一次設定所有標頭
+  output.setHeaders({
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, POST',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Cache-Control': 'no-store',
+  });
   return output;
 }
 


### PR DESCRIPTION
## Summary
- ensure Apps Script leaderboard endpoint sets CORS headers correctly
- call leaderboard API directly without extra proxy

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c03ce3850883288f84d4180e2e080c