### PR TITLE
Fix leaderboard CORS

### DIFF
--- a/index.html
+++ b/index.html
@@ -557,8 +557,13 @@ select optgroup { color: #0b1022; }
 (() => {
 
   const RANK_API = 'https://script.google.com/macros/s/AKfycbz3-sdGL3pCPUs3_dMjJdpL9GxbEkHux3Vf4CN-ehGNYnybrnxfmQpkhGrlv9VbmJbx/exec';
-  // 後端已支援 CORS，直接回傳原始 URL
-  const CORS = (url) => url;
+  // 使用 Apps Script 做排行榜時其回應缺少 CORS 標頭；
+  // 若從 GitHub Pages 等網域載入，需要透過代理補上 CORS。
+  const CORS = (url) => (
+    location.hostname.endsWith('.github.io')
+      ? 'https://cors.isomorphic-git.org/' + url
+      : url
+  );
   // === 設定 ===
   const GAME_CONFIG = {
     totalLevels: 20,


### PR DESCRIPTION
## Summary
- proxy leaderboard API through isomorphic-git CORS helper when hosted on GitHub Pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0458704288328b9e21b03a68550fa