### PR TITLE
Clarify TextOutput CORS header comment

### DIFF
--- a/leaderboard.gs
+++ b/leaderboard.gs
@@ -7,7 +7,7 @@ function getSheet() {
 }
 
 function setCors(output) {
-  // Apps Script 的 TextOutput 沒有 setHeader，需一次設定所有標頭
+  // TextOutput 支援 setHeader，CORS 標頭逐一設定
   output.setHeader('Access-Control-Allow-Origin', '*');
   output.setHeader('Access-Control-Allow-Methods', 'GET, POST');
   output.setHeader('Access-Control-Allow-Headers', 'Content-Type');


### PR DESCRIPTION
## Summary
- Correct the `setCors` comment to note TextOutput supports `setHeader` and CORS headers are set individually.

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c44a14e7dc8328b8b2721c14fffd40