### PR TITLE
Handle CORS preflight in leaderboard script

### DIFF
--- a/leaderboard.gs
+++ b/leaderboard.gs
@@ -105,3 +105,9 @@ function doGet(e) {
     return setCors(out);
   }
 }
+
+function doOptions(e) {
+  const out = ContentService.createTextOutput('')
+    .setMimeType(ContentService.MimeType.TEXT);
+  return setCors(out);
+}


### PR DESCRIPTION
## Summary
- add doOptions handler to send CORS headers for preflight requests

## Testing
- `node --check /tmp/leaderboard.js`
- ⚠️ `clasp deploy` *(failed: No credentials found)*

------
https://chatgpt.com/codex/tasks/task_e_68c44bf7cee48328a583aff2af29a10c