### PR TITLE
Refine Bunny Cream Cloud skin

### DIFF
--- a/index.html
+++ b/index.html
@@ -356,25 +356,38 @@ select optgroup { color: #0b1022; }
 
     /* === 兔兔·奶油雲朵 === */
     body[data-skin="兔兔·奶油雲朵"]{
-      --ink:#d4a017;
-      --muted:#b88f3a;
-      --stroke:rgba(255,255,255,.9);
-      --bg1:#ffe4f2;
-      --bg2:#fff5fa;
-      --hudGrad1:rgba(255,240,245,.86);
-      --hudGrad2:rgba(255,225,235,.72);
-      --glass-1:rgba(255,255,255,.18);
-      --glass-2:rgba(255,213,232,.45);
-      --stageGlass:linear-gradient(180deg, rgba(255,240,245,.1), transparent);
-      --panelPattern:radial-gradient(80px 80px at 20% 20%, rgba(255,200,220,.2), transparent 60%),
-                      radial-gradient(60px 60px at 80% 30%, rgba(255,255,255,.15), transparent 40%);
-      --btnGlow:0 0 20px rgba(255,200,220,.4);
+      --ink:#83685e;
+      --muted:#bfa7a0;
+      --stroke:rgba(255,255,255,.8);
+      --bg1:#fff5f9;
+      --bg2:#fffaf2;
+      --hudGrad1:rgba(255,255,255,.86);
+      --hudGrad2:rgba(255,240,248,.72);
+      --glass-1:rgba(255,255,255,.25);
+      --glass-2:rgba(255,230,240,.55);
+      --stageGlass:linear-gradient(180deg, rgba(255,245,250,.12), transparent);
+      --panelPattern:radial-gradient(60px 60px at 15% 20%, rgba(255,200,220,.15), transparent 60%),
+                      radial-gradient(40px 40px at 85% 25%, rgba(255,220,240,.2), transparent 50%);
+      --btnGlow:0 0 24px rgba(255,180,200,.5);
+      --heartGlow:rgba(255,180,200,.6);
+      background:radial-gradient(160% 160% at 50% -10%, #fff8fb 0%, #ffeef6 60%, #fffaf5 100%);
     }
 
     body[data-skin="兔兔·奶油雲朵"] canvas#game{position:relative;z-index:1;background:transparent;}
     body[data-skin="兔兔·奶油雲朵"] .hearts .life-icon{width:32px;height:32px;}
     body[data-skin="兔兔·奶油雲朵"] .hearts .life-icon svg{width:32px;height:32px;}
-    body[data-skin="兔兔·奶油雲朵"] .btn{background:#ffd5e8;color:#d4a017;border:2px solid #fff;}
+    body[data-skin="兔兔·奶油雲朵"] .btn{
+      background:linear-gradient(180deg,#fff1f5,#ffd6e5);
+      color:#8a5c5c;
+      border:2px solid #fff;
+      box-shadow:0 2px 8px rgba(255,170,200,.6);
+    }
+    body[data-skin="兔兔·奶油雲朵"] .ic-btn{
+      background:linear-gradient(145deg,#ffeef5,#ffe0ee);
+      color:#8a5c5c;
+      border:2px solid #fff;
+      box-shadow:inset 0 0 0 1px rgba(255,255,255,.6),0 4px 12px rgba(255,180,200,.5);
+    }
 
 /* HUD/按鍵的霓虹語彙（按鍵邊緣流光＋心形光暈） */
 

--- a/skin.js
+++ b/skin.js
@@ -189,19 +189,19 @@
     label: '兔兔·奶油雲朵',
     selectLabel: '兔兔·奶油雲朵',
     cssSkin: '兔兔·奶油雲朵',
-    lifeIcon: `<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg"><g fill="#fff" stroke="#e0e0e0" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="32" cy="40" rx="20" ry="16"/><ellipse cx="20" cy="18" rx="10" ry="20"/><ellipse cx="44" cy="18" rx="10" ry="20"/><circle cx="24" cy="36" r="6" fill="#000"/><circle cx="40" cy="36" r="6" fill="#000"/><circle cx="24" cy="34" r="2" fill="#fff"/><circle cx="40" cy="34" r="2" fill="#fff"/><circle cx="32" cy="44" r="3" fill="#ffb6c1"/><path d="M28 48Q32 52 36 48" stroke="#000" fill="none"/></g></svg>`,
+    lifeIcon: `<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg"><g fill="#fff" stroke="#f7d7e7" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="32" cy="40" rx="20" ry="16"/><ellipse cx="20" cy="18" rx="10" ry="20"/><ellipse cx="44" cy="18" rx="10" ry="20"/><circle cx="24" cy="36" r="6" fill="#000"/><circle cx="40" cy="36" r="6" fill="#000"/><circle cx="24" cy="34" r="2" fill="#fff"/><circle cx="40" cy="34" r="2" fill="#fff"/><circle cx="32" cy="44" r="3" fill="#ffb6c1"/><path d="M28 48Q32 52 36 48" stroke="#000" fill="none"/></g></svg>`,
     canvas: {
-      base: [255, 240, 220],
+      base: [255, 248, 245],
       hi: [255, 255, 255],
-      period: 3000,
+      period: 3500,
       effects: {
-        clouds: { count: 8, sizePx: 180, speed: 0.002, alpha: 0.25 },
-        balloons: { intervalMs: 10000, lifeMs: 40000, colors: ['#ff8aa0','#ffd966','#9ad0f5','#cfa0ff','#ffe599'] },
-        ledStrip: { hi: [255,255,255], lo: [255,240,200], period: 3000 }
+        clouds: { count: 10, sizePx: 160, speed: 0.003, alpha: 0.2 },
+        balloons: { intervalMs: 8000, lifeMs: 40000, colors: ['#ffb3d9','#ffe6a1','#cce6ff','#e5d0ff','#fff2b5'] },
+        ledStrip: { hi: [255,255,255], lo: [255,230,240], period: 3500 }
       },
-      bg: ['#aee1ff', '#fdfbff', '#ffffff']
+      bg: ['#ffe8f5', '#fffefc', '#ffffff']
     },
-    desc: '童話兔兔：奶油 HUD、草莓蛋糕按鈕、柔黃白 LED，棉花雲與氣球飄浮，3s 週期。'
+    desc: '奶油夢境：粉霜 HUD、棉花糖按鈕、柔粉白 LED，柔雲與氣球輕飄，3.5s 週期。'
   }
 };
 


### PR DESCRIPTION
## Summary
- Refresh Bunny Cream Cloud theme with pastel palette, heart glow, and gradient buttons
- Tune bunnyCream canvas effects for softer clouds, balloons, and LED pacing

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check skin.js`


------
https://chatgpt.com/codex/tasks/task_e_68c541d334b88328b0f271de13cdbff0