### PR TITLE
fix: prevent leaderboard overflow on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,7 +215,7 @@
     /* Leaderboard overlay */
     .rank-page{position:fixed;inset:0;display:none;z-index:75;align-items:center;justify-content:center;pointer-events:auto}
     .rank-page .backdrop{position:absolute;inset:0;background:rgba(0,0,0,.8)}
-    .rank-page .content{position:relative;z-index:2;width:min(96vw,960px);max-height:92vh;display:flex;flex-direction:column;background:linear-gradient(180deg,rgba(10,14,30,.95),rgba(10,14,30,.88));border:1px solid var(--glass-stroke);border-radius:16px;padding:12px;box-shadow:0 20px 90px rgba(0,0,0,.5)}
+    .rank-page .content{position:relative;z-index:2;width:min(96vw,960px);max-height:92vh;display:flex;flex-direction:column;background:linear-gradient(180deg,rgba(10,14,30,.95),rgba(10,14,30,.88));border:1px solid var(--glass-stroke);border-radius:16px;padding:12px;box-shadow:0 20px 90px rgba(0,0,0,.5);overflow:auto;min-width:0}
     .rank-page .close{align-self:flex-end;cursor:pointer;font-size:24px;line-height:1}
     .rank-page table{width:100%;border-collapse:collapse;font-size:14px;margin-top:4px}
     .rank-page th,.rank-page td{border:1px solid var(--stroke);padding:4px 6px;text-align:center}


### PR DESCRIPTION
## Summary
- stop leaderboard panel from expanding wider than the screen on mobile by letting it scroll and shrink

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c556a41e14832881e64f64e0c46194