### PR TITLE
Limit guaranteed drop to single-brick events

### DIFF
--- a/index.html
+++ b/index.html
@@ -2087,6 +2087,7 @@ function generateLevel(lv, L){
 
   // 道具掉落率抑制
   let burstStart=0, burstCount=0;
+  let pendingGoodDrop=null;
   function activePowerCount(){
     const now=performance.now();
     let cnt=0;
@@ -2113,8 +2114,18 @@ function generateLevel(lv, L){
     }
     const actives=activePowerCount();
     if(actives===0){
-      spawnPower(b.x + b.w/2 - 12, b.y + b.h/2, {forceGood:true});
-      return;
+      if(!pendingGoodDrop){
+        const px=b.x+b.w/2-12, py=b.y+b.h/2;
+        pendingGoodDrop={x:px,y:py};
+        setTimeout(()=>{
+          if(pendingGoodDrop && burstCount===1){
+            spawnPower(pendingGoodDrop.x, pendingGoodDrop.y, {forceGood:true});
+          }
+          pendingGoodDrop=null;
+        },0);
+        return;
+      }
+      // 已有保底掉落等待確認，後續磚塊走一般掉落計算
     }
     let rate=dropRateForLevel(level);
     if(actives>=5) rate*=0.3;


### PR DESCRIPTION
## Summary
- Only grant guaranteed drop when a single brick is destroyed with no active powers
- Use a deferred check to cancel the guarantee if multiple bricks break simultaneously

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c579a5ea5083288de67af244335eec