### PR TITLE
feat: unlockable special buffs with unlock notices

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,6 +143,7 @@
     .legend{display:flex;gap:8px;flex-wrap:wrap;align-items:center;justify-content:center;font-size:12px;color:#cfe0ff;margin-top:6px}
     .legend .item{padding:4px 8px;border-radius:10px;background:rgba(255,255,255,.05);border:1px solid var(--stroke);display:flex;align-items:center;gap:4px}
     .legend .box{width:14px;height:14px;border-radius:3px;display:inline-block;vertical-align:middle}
+    .sealed{opacity:0.4;filter:grayscale(100%)}
     #combo{
       position:absolute;
       top:8px;
@@ -634,6 +635,43 @@ select optgroup { color: #0b1022; }
     }
     return IMG_MAP[i];
   }
+
+  // === 特殊增益解鎖 ===
+  const SPECIAL_UNLOCK_LEVELS = {
+    PHOENIX:1,
+    GATLING:3,
+    SWORD:5,
+    GODSPEED:7,
+    STORM:9,
+    BLACKHOLE:10,
+    ANNIHIL:15,
+  };
+  const defaultUnlocked=['LASER','FLIP','NINE'];
+  let unlockedSpecials=new Set(defaultUnlocked);
+  try{
+    const stored=JSON.parse(localStorage.getItem('unlocked_specials')||'[]');
+    if(Array.isArray(stored)) stored.forEach(k=>unlockedSpecials.add(k));
+  }catch(e){}
+  function saveUnlockedSpecials(){
+    localStorage.setItem('unlocked_specials',JSON.stringify(Array.from(unlockedSpecials)));
+  }
+  let pendingUnlockNotice=null;
+  let ALL_TYPES=[]; let NORMAL_TYPES=[];
+  function recomputePowerTypes(){
+    ALL_TYPES=Object.keys(GAME_CONFIG.powers).filter(k=>GAME_CONFIG.powers[k].type!=='special'||unlockedSpecials.has(k));
+    NORMAL_TYPES=ALL_TYPES.filter(k=>GAME_CONFIG.powers[k].type!=='special');
+  }
+  function unlockSpecials(clearLevel){
+    for(const [key,req] of Object.entries(SPECIAL_UNLOCK_LEVELS)){
+      if(clearLevel>=req && !unlockedSpecials.has(key)){
+        unlockedSpecials.add(key);
+        saveUnlockedSpecials();
+        pendingUnlockNotice=`已解鎖特殊增益:${GAME_CONFIG.powers[key].label.split('(')[0]}`;
+        recomputePowerTypes();
+      }
+    }
+  }
+  recomputePowerTypes();
 
   // === 參考 DOM ===
   const canvas=document.getElementById('game'); const ctx=canvas.getContext('2d');
@@ -2029,7 +2067,7 @@ function generateLevel(lv, L){
   function fireCollide(){ if(buffs.FIRE.active){ fireEnergy++; updateFireEnergy(); } }
 
   // === 掉落道具 ===
-  const powerups=[]; const ALL_TYPES=Object.keys(GAME_CONFIG.powers); const NORMAL_TYPES=ALL_TYPES.filter(k=>GAME_CONFIG.powers[k].type!=='special');
+  const powerups=[];
 
   // === 天空隨機增益掉落（第1關每25秒 → 第20關每6秒 線性遞減） ===
   let nextSkyDropAt = 0;
@@ -2488,6 +2526,7 @@ function generateLevel(lv, L){
   function startGameWithCountdown(){
     onResumeFromPause();
     running=true; paused=true; hideCenter();
+    if(pendingUnlockNotice){ showComboNotice(pendingUnlockNotice); pendingUnlockNotice=null; }
     ensureAudio(); audioCtx?.resume?.();
     // 音效與BGM設定載入
     // 從 localStorage 載入音效與 BGM 設定
@@ -2564,7 +2603,11 @@ function generateLevel(lv, L){
         const p = GAME_CONFIG.powers[k];
         if(p.type === 'special'){
           const label = p.label + (p.desc ? `(${p.desc})` : '');
-          html += `${badgeIcon(k)} <em>${k}</em>：${label}<br>`;
+          if(unlockedSpecials.has(k)){
+            html += `${badgeIcon(k)} <em>${k}</em>：${label}<br>`;
+          }else{
+            html += `<span class="sealed">${badgeIcon(k)} <em>${k}</em>：${label}</span><br>`;
+          }
         }
       }
       html += '</div>';
@@ -3784,6 +3827,7 @@ function generateLevel(lv, L){
 
     // 清關（進入畫廊或通關）
     if(!hasBreakables()){
+      unlockSpecials(level);
       const idx=((level-1)%10);
       const type = (level<=10 ? (imageChoice[idx]===0?'bg':'cg') : (imageChoice[idx]===0?'cg':'bg'));
       markImageUnlocked(type, idx);


### PR DESCRIPTION
## Summary
- add permanent unlock system for special power-ups tied to cleared levels
- show marquee notice when a special power is unlocked on entering the next stage
- gray out locked special power descriptions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c58e8be9fc8328bb949ee6402a6e40