### PR TITLE
Track kills on ball brick collision

### DIFF
--- a/index.html
+++ b/index.html
@@ -3895,12 +3895,19 @@ function generateLevel(lv, L){
           if(!(bk.lockedUntil && now<bk.lockedUntil)){
             bk.hp=(bk.hp||1)-1; incrementCombo();
             if(bk.hp<=0){
-              addScore(scoreForBrick(bk)); updateHUD();
               const cx=bk.x+bk.w/2, cy=bk.y+bk.h/2;
+              if(!bk.explosive){
+                if(bk.boss) stats.bossKills++;
+                if(bk.elite) stats.eliteKills++;
+                addScore(scoreForBrick(bk));
+              } else {
+                addScore(scoreForBrick(bk));
+              }
               revealBrickArea(bk);
               if(inRampage || b.piercing) playSFX('pierce');
               maybeDropFromBrick(bk);
-              if(bk.explosive){ explodeAt(cx,cy); } else { bricks.splice(hit,1); }
+              if(bk.explosive){ explodeAt(cx,cy); }
+              else { bricks.splice(hit,1); updateHUD(); }
             } else updateHUD();
           }
         }


### PR DESCRIPTION
## Summary
- Increment boss and elite kill counters when a brick is destroyed by the ball
- Defer HUD updates until after non-explosive bricks are removed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c4dd27308328a2e76e2dad068bfa