### PR TITLE
feat: limit leaderboard name length

### DIFF
--- a/index.html
+++ b/index.html
@@ -976,10 +976,17 @@ select optgroup { color: #0b1022; }
       alert('已上傳過，請勿再次上傳');
       return;
     }
-    const name = prompt('請輸入玩家名稱：');
+    const rawName = prompt('請輸入玩家名稱：\n注意: 姓名最多輸入8個字');
+    if(rawName==null) return;
+    const name = (rawName||'').trim();
     if(!name) return;
+    if([...(name||'')].length>8){
+      alert('名字這麼長是想怎樣啦? 請重新輸入!');
+      setTimeout(uploadScore,3000);
+      return;
+    }
     const payload = {
-      name: (name||'').trim(),
+      name,
       score,
       lives: stats.livesUsed,
       catches: stats.catches,


### PR DESCRIPTION
## Summary
- add warning about 8-character name limit when uploading score
- reject overly long names with playful message and re-prompt after 3 seconds

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e14c4fb0832892444f2c9e5ddac1