### PR TITLE
Prompt for shorter name on upload

### DIFF
--- a/index.html
+++ b/index.html
@@ -982,8 +982,7 @@ select optgroup { color: #0b1022; }
     if(!name) return;
     if([...(name||'')].length>8){
       alert('名字這麼長是想怎樣啦? 請重新輸入!');
-      setTimeout(uploadScore,3000);
-      return;
+      return uploadScore();
     }
     const payload = {
       name,


### PR DESCRIPTION
## Summary
- Retry score upload name prompt immediately when name is longer than 8 chars, without 3-second delay.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e66bb1ac83288a974c3122a85f62