### PR TITLE
Add Infinite Castle skin with background and styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# User-provided Infinite Castle background
+images/d1.jpg

--- a/index.html
+++ b/index.html
@@ -375,6 +375,25 @@ select optgroup { color: #0b1022; }
                       radial-gradient(50px 50px at 80% 60%, rgba(160,110,50,.1), transparent 60%);
       --btnGlow:0 0 18px rgba(255,190,90,.25);
     }
+    /* === 和風．無限之城 === */
+    body[data-skin="和風．無限之城"]{
+      --ink:#ffedc2;
+      --muted:#cbb07a;
+      --stroke:rgba(247,227,174,.35);
+      --bg1:#130a00;
+      --bg2:#060300;
+      --hudGrad1:rgba(80,60,20,.55);
+      --hudGrad2:rgba(50,35,10,.45);
+      --glass-1:rgba(255,255,255,.08);
+      --glass-2:rgba(255,255,255,.05);
+      --stageGlass:linear-gradient(180deg, rgba(255,200,120,.07), transparent);
+      --panelPattern:none;
+      --btnGlow:0 0 20px rgba(255,200,120,.25);
+    }
+    body[data-skin="和風．無限之城"] #game{
+      background:url("images/d1.jpg") center/cover no-repeat;
+    }
+
 /* HUD/按鍵的霓虹語彙（按鍵邊緣流光＋心形光暈） */
 
 

--- a/skin.js
+++ b/skin.js
@@ -183,6 +183,23 @@
       bg: ['#3d2b1f', '#22160e', '#0e0b08']
     },
     desc: '銅黃齒輪搭深木板，齒輪鏈轉動；琥珀 LED 呼吸，工廠齒輪背景。'
+  },
+  infiniteCastle: {
+    label: '和風．無限之城',
+    selectLabel: '和風．無限之城',
+    cssSkin: '和風．無限之城',
+    lifeIcon: `<svg viewBox="0 0 32 32">
+      <path d="M2 4 L30 28 M2 4 l6-2 l2 6 M30 28 l-6 2 l-2-6"
+            stroke="#ffedc2" stroke-width="3" fill="none"
+            stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>`,
+    canvas: {
+      base: [210, 160, 70],
+      hi: [255, 235, 150],
+      period: 2400,
+      effects: {},
+      bg: null
+    }
   }
 };
 


### PR DESCRIPTION
## Summary
- add new "和風．無限之城" skin with custom canvas colors and katana life icon
- style rules and background image for the Infinite Castle skin
- remove binary background image and ignore user-provided asset

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ffd902e48328a882732be8efc946