### PR TITLE
Fix Infinite Castle background image reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -391,7 +391,7 @@ select optgroup { color: #0b1022; }
       --btnGlow:0 0 20px rgba(255,200,120,.25);
     }
     body[data-skin="和風．無限之城"] #game{
-      background:url("images/d1.jpg") center/cover no-repeat;
+      background:url("images/d1.png") center/cover no-repeat;
     }
 
 /* HUD/按鍵的霓虹語彙（按鍵邊緣流光＋心形光暈） */


### PR DESCRIPTION
## Summary
- Correct image reference for the 和風．無限之城 skin to use existing `d1.png`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c705b26cc88328b4ea2acf036abce7