### PR TITLE
Fix background for 和風．無限之城 skin

### DIFF
--- a/index.html
+++ b/index.html
@@ -391,7 +391,8 @@ select optgroup { color: #0b1022; }
       --btnGlow:0 0 20px rgba(255,200,120,.25);
     }
     body[data-skin="和風．無限之城"] #game{
-      background:url("images/d1.JPG") hcenter/cover no-repeat;
+      /* 修正背景位置屬性拼寫錯誤，確保圖片正常顯示 */
+      background:url("images/d1.JPG") center/cover no-repeat;
     }
 
 /* HUD/按鍵的霓虹語彙（按鍵邊緣流光＋心形光暈） */


### PR DESCRIPTION
## Summary
- correct background shorthand syntax for 和風．無限之城 skin so d1.JPG loads properly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c76e20bedc8328a549ba219cc08d91