### PR TITLE
Fix help window reopen requiring double click

### DIFF
--- a/index.html
+++ b/index.html
@@ -1108,6 +1108,7 @@ select optgroup { color: #0b1022; }
   const noteClose = document.getElementById('noteClose');
   function closeNoteAndResume(){
     hideCenter();
+    helpMode = null;
     // 在關閉說明視窗後恢復遊戲：先調整所有計時，再透過倒數繼續
     if(menusOpen()) return;
     if(running){ onResumeFromPause(); startCountdown(); } else { startGameWithCountdown(); }


### PR DESCRIPTION
## Summary
- reset help mode when closing center notes so teaching/effects dialogs reopen immediately

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c7834692bc8328b92f89ac08f7396c