### PR TITLE
Prevent boss bricks from taking damage

### DIFF
--- a/index.html
+++ b/index.html
@@ -5288,8 +5288,10 @@ function generateLevel(lv, L){
 
         // 當前磚扣血（若已在上面被處理則略過）
         if(!buffs.HELL.active && !buffs.HOLY.active){
-          // 鎖鏈中不受傷害
-          if(!(bk.lockedUntil && now<bk.lockedUntil)){
+          // 不可破壞／鎖鏈狀態下不扣血
+          if(bk.unbreakable || (bk.lockedUntil && now<bk.lockedUntil)){
+            if(bk.boss){ updateHUD(); }
+          }else{
             bk.hp=(bk.hp||1)-1; incrementCombo();
             if(bk.hp<=0){
               const cx=bk.x+bk.w/2, cy=bk.y+bk.h/2;


### PR DESCRIPTION
## Summary
- stop the ball collision handler from reducing HP on unbreakable bricks so boss tiles remain invulnerable

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cb8d063fec8328b95286c4f257cf28