### PR TITLE
Integrate level 10 reaper boss with shared boss systems

### DIFF
--- a/index.html
+++ b/index.html
@@ -1302,8 +1302,25 @@ select optgroup { color: #0b1022; }
   let spaceBossPrevPaddleCenter=0;
   let spaceBossSuppressLifeLossUntil=0;
 
+  let reaperPhase='inactive';
+  let reaperBoss=null;
+  let reaperPlaceholder=null;
+  let reaperAnchor=null;
+  let reaperRevealScheduled=0;
+  let reaperBursts=[];
+  let reaperAfterimages=[];
+  let reaperMarquee=null;
+  let reaperDefeatedAt=0;
+  let reaperDeathAnim=null;
+  let reaperTeleportSchedule=null;
+  let reaperTargetHighlightUntil=0;
+
   function isSpaceBossActive(){
     return level===5 && spaceBossPhase==='active' && !!spaceBoss;
+  }
+
+  function isReaperActive(){
+    return level===10 && reaperPhase==='active' && !!reaperBoss;
   }
 
   function getSpaceBossBounds(){
@@ -1318,6 +1335,26 @@ select optgroup { color: #0b1022; }
 
   function circleIntersectsSpaceBoss(cx, cy, radius){
     const bounds=getSpaceBossBounds();
+    if(!bounds) return false;
+    const nearestX = Math.max(bounds.x, Math.min(cx, bounds.x + bounds.w));
+    const nearestY = Math.max(bounds.y, Math.min(cy, bounds.y + bounds.h));
+    const dx = cx - nearestX;
+    const dy = cy - nearestY;
+    return dx*dx + dy*dy <= radius*radius;
+  }
+
+  function getReaperBounds(){
+    if(!reaperBoss) return null;
+    return {
+      x: reaperBoss.x - reaperBoss.w/2,
+      y: reaperBoss.y - reaperBoss.h/2,
+      w: reaperBoss.w,
+      h: reaperBoss.h
+    };
+  }
+
+  function circleIntersectsReaper(cx, cy, radius){
+    const bounds=getReaperBounds();
     if(!bounds) return false;
     const nearestX = Math.max(bounds.x, Math.min(cx, bounds.x + bounds.w));
     const nearestY = Math.max(bounds.y, Math.min(cy, bounds.y + bounds.h));
@@ -1356,7 +1393,45 @@ select optgroup { color: #0b1022; }
     return {x: targetX, y: targetY};
   }
 
+  function reaperImpactPoint(fromX, fromY){
+    const bounds=getReaperBounds();
+    if(!bounds) return {x:fromX, y:fromY};
+    const targetX = reaperBoss.x;
+    const targetY = reaperBoss.y;
+    const dx = targetX - fromX;
+    const dy = targetY - fromY;
+    let bestT = Infinity;
+    function test(t){
+      if(t<=0 || t>=1e6) return;
+      const ix = fromX + dx*t;
+      const iy = fromY + dy*t;
+      if(ix>=bounds.x-1e-6 && ix<=bounds.x+bounds.w+1e-6 && iy>=bounds.y-1e-6 && iy<=bounds.y+bounds.h+1e-6){
+        if(t<bestT) bestT=t;
+      }
+    }
+    if(Math.abs(dx)>1e-6){
+      test((bounds.x - fromX)/dx);
+      test((bounds.x + bounds.w - fromX)/dx);
+    }
+    if(Math.abs(dy)>1e-6){
+      test((bounds.y - fromY)/dy);
+      test((bounds.y + bounds.h - fromY)/dy);
+    }
+    if(bestT!==Infinity){
+      return {x: fromX + dx*bestT, y: fromY + dy*bestT};
+    }
+    return {x: targetX, y: targetY};
+  }
+
   function highlightSpaceBossTarget(){
+    if(isReaperActive()){
+      const bounds=getReaperBounds();
+      if(bounds){
+        reaperTargetHighlightUntil = Math.max(reaperTargetHighlightUntil, performance.now()+600);
+        pushLockBox(bounds.x, bounds.y, bounds.w, bounds.h, 'target');
+      }
+      return;
+    }
     const bounds=getSpaceBossBounds();
     if(bounds){ pushLockBox(bounds.x, bounds.y, bounds.w, bounds.h, 'target'); }
   }
@@ -2300,6 +2375,18 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
     spaceBossDeathAnim=null;
     spaceBossSuppressLifeLossUntil=0;
     spaceBossPhase = (level===5?'awaiting':'inactive');
+    reaperBoss=null;
+    reaperAnchor=null;
+    reaperPlaceholder=null;
+    reaperBursts=[];
+    reaperAfterimages=[];
+    reaperMarquee=null;
+    reaperRevealScheduled=0;
+    reaperDefeatedAt=0;
+    reaperDeathAnim=null;
+    reaperTeleportSchedule=null;
+    reaperTargetHighlightUntil=0;
+    reaperPhase = (level===10?'awaiting':'inactive');
     const lvlImg = getLevelImage(level);
     if (lvlImg && lvlImg.decode) { lvlImg.decode().catch(()=>{}); }
     // 依關卡設計關卡布局
@@ -2326,6 +2413,17 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
       if(spaceBossPhase==='awaiting'){ startSpaceBossReveal(); return true; }
       if(spaceBossPhase==='intro' || spaceBossPhase==='active' || spaceBossPhase==='dying') return true;
       if(spaceBossPhase==='defeated' && spaceBossDefeatedAt && now < spaceBossDefeatedAt + 3000){
+        return true;
+      }
+      return false;
+    }
+    if(level===10){
+      const now=performance.now();
+      const breakables = bricks.some(b => !b.unbreakable && !b.placeholderBoss);
+      if(breakables) return true;
+      if(reaperPhase==='awaiting'){ startReaperReveal(); return true; }
+      if(reaperPhase==='intro' || reaperPhase==='active' || reaperPhase==='dying') return true;
+      if(reaperPhase==='defeated' && reaperDefeatedAt && now < reaperDefeatedAt + 3000){
         return true;
       }
       return false;
@@ -3225,6 +3323,580 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
     drawSpaceBossHPBar();
   }
 
+  // === 第10關 暗黑死神 Boss ===
+  function startReaperReveal(){
+    if(reaperPhase!=='awaiting') return;
+    const now=performance.now();
+    reaperPhase='intro';
+    let anchor=reaperAnchor;
+    if(reaperPlaceholder){
+      anchor={x:reaperPlaceholder.x, y:reaperPlaceholder.y, w:reaperPlaceholder.w, h:reaperPlaceholder.h};
+      const cx=anchor.x+anchor.w/2;
+      const cy=anchor.y+anchor.h/2;
+      spawnParticles(cx,cy,'#fdf0ff',140,3.2,5.2,5.6);
+      spawnParticles(cx,cy,'#c4a6ff',110,2.8,4.4,4.8);
+      spawnParticles(cx,cy,'#ff96cf',90,2.4,3.8,4.2);
+      reaperBursts.push({type:'ring',x:cx,y:cy,r0:28,r1:420,width:18,t0:now,life:1400,color:'220,140,255'});
+      reaperBursts.push({type:'flare',x:cx,y:cy,r0:0,r1:260,t0:now,life:1200,color:'150,110,220'});
+      reaperBursts.push({type:'spark',x:cx,y:cy,r0:0,r1:180,t0:now,life:950,color:'255,160,220'});
+      const idx=bricks.indexOf(reaperPlaceholder);
+      if(idx>=0) bricks.splice(idx,1);
+      reaperPlaceholder=null;
+      reaperAnchor=anchor;
+    }
+    if(!reaperAnchor){
+      const L=layout();
+      const bx=Math.floor(L.cols/2)-1;
+      const anchorW=brickW*2+L.pad;
+      const anchorH=brickH*2+L.pad;
+      const anchorX=L.pad + bx*(brickW+L.pad);
+      reaperAnchor={x:anchorX,y:L.top,w:anchorW,h:anchorH};
+    }
+    reaperRevealScheduled = now + 900;
+    reaperMarquee={text:'有一套！ 讓我親自會會你!', start:now, fadeStart:now+5000, end:now+8000, style:'alert'};
+    screenShake=Math.max(screenShake,8);
+    playSFX('fireExplosion');
+  }
+
+  function activateReaperBoss(){
+    if(reaperPhase!=='intro' || reaperBoss) return;
+    let anchor=reaperAnchor;
+    if(!anchor){
+      const L=layout();
+      const bx=Math.floor(L.cols/2)-1;
+      anchor={x:L.pad + bx*(brickW+L.pad), y:L.top, w:brickW*2+L.pad, h:brickH*2+L.pad};
+      reaperAnchor=anchor;
+    }
+    const cx=anchor.x+anchor.w/2;
+    const baseY=anchor.y+anchor.h+140;
+    const now=performance.now();
+    reaperBoss={
+      x:cx,
+      y:baseY,
+      baseY,
+      w:160,
+      h:220,
+      vx:(Math.random()<0.5?-1:1)*1.6,
+      hp:40,
+      maxHp:40,
+      hitCooldownUntil:0,
+      hitFlashUntil:0,
+      spawnAt:now,
+      cloakPhase:Math.random()*Math.PI*2
+    };
+    reaperTeleportSchedule={
+      nextSingle: now + 10000,
+      nextBurst: now + 30000,
+      burstRemaining: 0,
+      burstInterval: 220,
+      nextBurstTeleport: 0,
+      burstActive:false
+    };
+    reaperPhase='active';
+    reaperBursts.push({type:'halo',x:cx,y:baseY-40,r0:60,r1:320,t0:now,life:1700,color:'200,140,255'});
+    screenShake=Math.max(screenShake,6);
+  }
+
+  function performReaperTeleport(rapid=false){
+    if(!reaperBoss) return;
+    const now=performance.now();
+    const oldX=reaperBoss.x;
+    const oldY=reaperBoss.y;
+    reaperAfterimages.push({x:oldX,y:oldY,t0:now,life:700,scale:1});
+    const L=layout();
+    const minX=140, maxX=1100-140;
+    const minY=L.top+90, maxY=L.top+320;
+    reaperBursts.push({type:'ring',x:oldX,y:oldY,r0:30,r1:260,width:16,t0:now,life:800,color:'210,130,255'});
+    reaperBursts.push({type:'flare',x:oldX,y:oldY,r0:0,r1:200,t0:now,life:720,color:'150,110,220'});
+    const newX = minX + Math.random()*(maxX-minX);
+    const newY = minY + Math.random()*(maxY-minY);
+    reaperBoss.x = newX;
+    reaperBoss.y = newY;
+    reaperAfterimages.push({x:newX,y:newY,t0:now,life:520,scale:1.12,emerge:true});
+    reaperBursts.push({type:'flare',x:newX,y:newY,r0:0,r1:240,t0:now,life:760,color:'255,150,210'});
+    const freq=rapid?760:680;
+    beep(freq,0.04,0.04);
+    beep(freq-240,0.03,0.05);
+    screenShake=Math.max(screenShake, rapid?4:3);
+  }
+
+  function damageReaperBoss(amount=1, source='generic', impact){
+    if(reaperPhase!=='active' || !reaperBoss) return false;
+    const now=performance.now();
+    if(reaperBoss.hitCooldownUntil && now<reaperBoss.hitCooldownUntil) return false;
+    const dmg = amount>0?1:0;
+    if(!dmg) return false;
+    reaperBoss.hitCooldownUntil = now + 160;
+    reaperBoss.hp = Math.max(0, reaperBoss.hp - dmg);
+    reaperBoss.hitFlashUntil = now + 260;
+    const jitterX=(Math.random()-0.5)*reaperBoss.w*0.35;
+    const jitterY=(Math.random()-0.5)*reaperBoss.h*0.25;
+    const colorMap={
+      laser:'240,190,255',
+      missile:'255,200,200',
+      gatling:'255,210,200',
+      plasma:'200,230,255',
+      blackhole:'210,220,255',
+      phoenix:'255,180,210',
+      sword:'255,200,220',
+      holy:'255,240,220'
+    };
+    const burstColor=colorMap[source]||'210,150,255';
+    reaperBursts.push({type:'spark',x:reaperBoss.x+jitterX,y:reaperBoss.y+jitterY,r0:0,r1:150,t0:now,life:720,color:burstColor});
+    spawnParticles(reaperBoss.x+jitterX, reaperBoss.y+jitterY, '#d9c7ff', 20, 1.5, 2.6, 2.4);
+    if(impact && impact.x!=null && impact.y!=null){
+      spawnParticles(impact.x, impact.y, '#ff9bd0', 16, 1.4, 2.4, 2.2);
+    }
+    screenShake=Math.max(screenShake,5);
+    const toneMap={laser:760, missile:680, gatling:720, plasma:780, blackhole:660, phoenix:820, sword:880, ball:800, holy:920};
+    const freq=toneMap[source]||780;
+    beep(freq,0.04,0.04);
+    if(reaperBoss.hp<=0){ defeatReaperBoss(); }
+    return true;
+  }
+
+  function defeatReaperBoss(){
+    if(reaperPhase!=='active' || !reaperBoss) return;
+    const now=performance.now();
+    const rb=reaperBoss;
+    addScore(scoreForBrick({boss:true}));
+    stats.bossKills++;
+    updateHUD();
+    reaperPhase='dying';
+    reaperDefeatedAt=now;
+    reaperTeleportSchedule=null;
+    reaperDeathAnim={
+      start:now,
+      startY:rb.y,
+      dropDistance:260,
+      fallDuration:3000,
+      bigExplosionStart:now+3000,
+      bigExplosionEnd:now+5000,
+      vanishAt:now+5000,
+      finishAt:now+8000,
+      lastBurst:now,
+      bigBang:false,
+      lastX:rb.x,
+      lastY:rb.y
+    };
+    reaperBursts.push({type:'ring',x:rb.x,y:rb.y,r0:60,r1:560,width:26,t0:now,life:2200,color:'255,170,230'});
+    reaperBursts.push({type:'flare',x:rb.x,y:rb.y,r0:0,r1:360,t0:now,life:1900,color:'210,140,255'});
+    spawnParticles(rb.x, rb.y, '#ffe5ff', 180, 3.4, 5.6, 6.2);
+    screenShake=Math.max(screenShake,14);
+    playSFX('fireExplosion');
+    reaperMarquee={text:'成功擊殺Boss: 暗黑死神!', start:now, fadeStart:now+5000, end:now+5000, style:'victorySolid'};
+  }
+
+  function updateReaperBoss(){
+    if(level!==10) return;
+    const now=performance.now();
+    if(reaperPhase==='intro' && !reaperBoss && reaperRevealScheduled && now>=reaperRevealScheduled){ activateReaperBoss(); }
+    if(reaperPhase==='active' && reaperBoss){
+      reaperBoss.x += reaperBoss.vx;
+      const margin=150;
+      if(reaperBoss.x - reaperBoss.w/2 < margin){ reaperBoss.x = margin + reaperBoss.w/2; reaperBoss.vx = Math.abs(reaperBoss.vx); }
+      if(reaperBoss.x + reaperBoss.w/2 > 1100 - margin){ reaperBoss.x = 1100 - margin - reaperBoss.w/2; reaperBoss.vx = -Math.abs(reaperBoss.vx); }
+      reaperBoss.y = reaperBoss.baseY + Math.sin((now - reaperBoss.spawnAt)/780)*42;
+      reaperBoss.cloakPhase += 0.03;
+      if(reaperTeleportSchedule){
+        if(reaperTeleportSchedule.burstActive){
+          if(now>=reaperTeleportSchedule.nextBurstTeleport){
+            performReaperTeleport(true);
+            reaperTeleportSchedule.burstRemaining--;
+            if(reaperTeleportSchedule.burstRemaining>0){
+              reaperTeleportSchedule.nextBurstTeleport = now + reaperTeleportSchedule.burstInterval;
+            }else{
+              reaperTeleportSchedule.burstActive=false;
+              reaperTeleportSchedule.nextSingle = now + 10000;
+              reaperTeleportSchedule.nextBurst = now + 30000;
+            }
+          }
+        }else if(now>=reaperTeleportSchedule.nextBurst){
+          reaperTeleportSchedule.burstActive=true;
+          reaperTeleportSchedule.burstRemaining=5;
+          reaperTeleportSchedule.nextBurstTeleport=now;
+          performReaperTeleport(true);
+          reaperTeleportSchedule.burstRemaining--;
+          if(reaperTeleportSchedule.burstRemaining>0){
+            reaperTeleportSchedule.nextBurstTeleport = now + reaperTeleportSchedule.burstInterval;
+          }else{
+            reaperTeleportSchedule.burstActive=false;
+            reaperTeleportSchedule.nextSingle = now + 10000;
+            reaperTeleportSchedule.nextBurst = now + 30000;
+          }
+        }else if(now>=reaperTeleportSchedule.nextSingle){
+          performReaperTeleport(false);
+          reaperTeleportSchedule.nextSingle = now + 10000;
+        }
+      }
+    }
+    if(reaperPhase==='dying' && reaperBoss){
+      const anim=reaperDeathAnim;
+      if(anim){
+        const elapsed=now-anim.start;
+        const prog=Math.max(0, Math.min(1, elapsed/anim.fallDuration));
+        reaperBoss.y = anim.startY + anim.dropDistance*prog;
+        reaperBoss.vx = 0;
+        anim.lastX = reaperBoss.x;
+        anim.lastY = reaperBoss.y;
+        if(now-anim.lastBurst>=320 && now<anim.bigExplosionStart){
+          anim.lastBurst=now;
+          const sx=reaperBoss.x + (Math.random()-0.5)*reaperBoss.w*0.7;
+          const sy=reaperBoss.y + (Math.random()-0.5)*reaperBoss.h*0.7;
+          reaperBursts.push({type:'spark',x:sx,y:sy,r0:0,r1:160,t0:now,life:820,color:'255,170,220'});
+          spawnParticles(sx, sy, '#ffd9f1', 28, 1.8, 3.0, 3.4);
+        }
+        if(!anim.bigBang && now>=anim.bigExplosionStart){
+          anim.bigBang=true;
+          const bx=anim.lastX;
+          const by=anim.lastY;
+          spawnParticles(bx, by, '#fff0ff', 240, 3.6, 6.0, 6.4);
+          reaperBursts.push({type:'ring',x:bx,y:by,r0:80,r1:620,width:30,t0:now,life:2200,color:'255,200,240'});
+          reaperBursts.push({type:'flare',x:bx,y:by,r0:0,r1:420,t0:now,life:2000,color:'230,170,255'});
+          screenShake=Math.max(screenShake,16);
+          playSFX('fireExplosion');
+        }
+        if(now>=anim.vanishAt){
+          reaperBoss=null;
+        }
+        if(now>=anim.finishAt){
+          reaperPhase='defeated';
+        }
+      }
+    }
+    for(let i=reaperBursts.length-1;i>=0;i--){ const fx=reaperBursts[i]; const life=fx.life||1000; if(now>fx.t0+life) reaperBursts.splice(i,1); }
+    for(let i=reaperAfterimages.length-1;i>=0;i--){ const af=reaperAfterimages[i]; if(now>af.t0+(af.life||600)) reaperAfterimages.splice(i,1); }
+  }
+
+  function drawReaperBoss(rb, now){
+    const s=(scaleX+scaleY)/2;
+    ctx.save();
+    ctx.translate(rb.x*scaleX, rb.y*scaleY);
+    const bodyW=rb.w*0.6*s;
+    const bodyH=rb.h*0.6*s;
+    const wave=Math.sin(now/420 + rb.cloakPhase)*0.18;
+    ctx.save();
+    ctx.beginPath();
+    ctx.moveTo(-bodyW*0.55, bodyH*0.5);
+    ctx.quadraticCurveTo(-bodyW*0.3, bodyH*(-0.2+wave), -bodyW*0.2, -bodyH*0.6);
+    ctx.quadraticCurveTo(0, -bodyH*0.74, bodyW*0.2, -bodyH*0.6);
+    ctx.quadraticCurveTo(bodyW*0.32, bodyH*(-0.2-wave), bodyW*0.55, bodyH*0.5);
+    ctx.quadraticCurveTo(0, bodyH*(0.78+wave*0.6), -bodyW*0.55, bodyH*0.5);
+    const cloakGrad=ctx.createLinearGradient(0,-bodyH*0.8,0,bodyH*0.8);
+    cloakGrad.addColorStop(0,'rgba(90,40,130,0.95)');
+    cloakGrad.addColorStop(1,'rgba(20,10,40,0.98)');
+    ctx.fillStyle=cloakGrad;
+    ctx.shadowColor='rgba(160,110,255,0.4)';
+    ctx.shadowBlur=26*s;
+    ctx.fill();
+    ctx.shadowBlur=0;
+    if(rb.hitFlashUntil && now<rb.hitFlashUntil){
+      ctx.strokeStyle='rgba(255,180,220,0.9)';
+      ctx.lineWidth=4*s;
+      ctx.stroke();
+    }
+    ctx.restore();
+    // Head
+    const headR=bodyW*0.28;
+    const headY=-bodyH*0.72;
+    const headGrad=ctx.createRadialGradient(0, headY, headR*0.2, 0, headY, headR);
+    headGrad.addColorStop(0,'rgba(255,255,255,0.95)');
+    headGrad.addColorStop(1,'rgba(130,90,180,0.95)');
+    ctx.fillStyle=headGrad;
+    ctx.beginPath();
+    ctx.arc(0, headY, headR, 0, Math.PI*2);
+    ctx.fill();
+    // Eyes
+    ctx.fillStyle='rgba(255,90,120,0.95)';
+    ctx.beginPath(); ctx.ellipse(-headR*0.35, headY, headR*0.22, headR*0.08, 0, 0, Math.PI*2); ctx.fill();
+    ctx.beginPath(); ctx.ellipse(headR*0.35, headY, headR*0.22, headR*0.08, 0, 0, Math.PI*2); ctx.fill();
+    // Scythe handle
+    ctx.save();
+    ctx.rotate(-0.45 + Math.sin(now/520 + rb.cloakPhase)*0.06);
+    ctx.strokeStyle='rgba(200,180,255,0.75)';
+    ctx.lineWidth=6*s;
+    ctx.beginPath();
+    ctx.moveTo(bodyW*0.3, -bodyH*0.05);
+    ctx.lineTo(bodyW*0.72, -bodyH*0.85);
+    ctx.stroke();
+    ctx.restore();
+    // Scythe blade
+    ctx.save();
+    ctx.translate(bodyW*0.72, -bodyH*0.85);
+    ctx.rotate(-0.1 + Math.sin(now/360 + rb.cloakPhase)*0.05);
+    ctx.beginPath();
+    ctx.moveTo(0,0);
+    ctx.quadraticCurveTo(bodyW*0.28, -bodyH*0.22, bodyW*0.22, bodyH*0.24);
+    ctx.quadraticCurveTo(bodyW*0.06, bodyH*0.2, 0, bodyH*0.12);
+    ctx.closePath();
+    const bladeGrad=ctx.createLinearGradient(0,-bodyH*0.22, bodyW*0.3, bodyH*0.26);
+    bladeGrad.addColorStop(0,'rgba(255,220,240,0.95)');
+    bladeGrad.addColorStop(1,'rgba(255,70,110,0.9)');
+    ctx.fillStyle=bladeGrad;
+    ctx.fill();
+    ctx.strokeStyle='rgba(255,255,255,0.85)';
+    ctx.lineWidth=2.4*s;
+    ctx.stroke();
+    ctx.restore();
+    // Floating aura
+    ctx.save();
+    const auraGrad=ctx.createRadialGradient(0, bodyH*0.2, bodyW*0.2, 0, bodyH*0.2, bodyW*1.1);
+    auraGrad.addColorStop(0,'rgba(180,120,255,0.25)');
+    auraGrad.addColorStop(1,'rgba(180,120,255,0)');
+    ctx.globalCompositeOperation='lighter';
+    ctx.fillStyle=auraGrad;
+    ctx.beginPath();
+    ctx.arc(0, bodyH*0.2, bodyW*1.1, 0, Math.PI*2);
+    ctx.fill();
+    ctx.restore();
+    ctx.restore();
+  }
+
+  function drawReaperLayer(){
+    if(level!==10) return;
+    if(reaperPhase==='inactive' && !reaperBursts.length && !reaperAfterimages.length) return;
+    const now=performance.now();
+    const easeOut=t=>1-Math.pow(1-Math.max(0,Math.min(1,t)),3);
+    for(const fx of reaperBursts){
+      const life=fx.life||1000;
+      const prog=Math.max(0, Math.min(1, (now-fx.t0)/life));
+      ctx.save();
+      ctx.globalCompositeOperation='lighter';
+      if(fx.type==='ring'){
+        const rad=(fx.r0||0)+((fx.r1||220)-(fx.r0||0))*easeOut(prog);
+        const alpha=1-prog;
+        ctx.strokeStyle=`rgba(${fx.color||'220,150,255'},${0.55*alpha})`;
+        ctx.lineWidth=(fx.width||16)*((scaleX+scaleY)/2)*(1-prog*0.7);
+        ctx.beginPath();
+        ctx.arc(fx.x*scaleX, fx.y*scaleY, rad*((scaleX+scaleY)/2),0,Math.PI*2);
+        ctx.stroke();
+      }else if(fx.type==='flare'){
+        const rad=(fx.r1||220)*easeOut(prog);
+        const grad=ctx.createRadialGradient(fx.x*scaleX, fx.y*scaleY, 0, fx.x*scaleX, fx.y*scaleY, Math.max(10, rad*((scaleX+scaleY)/2)));
+        grad.addColorStop(0, `rgba(${fx.color||'200,140,255'},${0.36*(1-prog)})`);
+        grad.addColorStop(1, 'rgba(0,0,0,0)');
+        ctx.fillStyle=grad;
+        ctx.beginPath();
+        ctx.arc(fx.x*scaleX, fx.y*scaleY, rad*((scaleX+scaleY)/2),0,Math.PI*2);
+        ctx.fill();
+      }else if(fx.type==='spark'){
+        const rad=(fx.r1||90)*prog*((scaleX+scaleY)/2);
+        ctx.strokeStyle=`rgba(${fx.color||'220,160,255'},${0.7*(1-prog)})`;
+        ctx.lineWidth=2.4*((scaleX+scaleY)/2);
+        ctx.beginPath();
+        ctx.moveTo(fx.x*scaleX-rad, fx.y*scaleY);
+        ctx.lineTo(fx.x*scaleX+rad, fx.y*scaleY);
+        ctx.moveTo(fx.x*scaleX, fx.y*scaleY-rad);
+        ctx.lineTo(fx.x*scaleX, fx.y*scaleY+rad);
+        ctx.stroke();
+      }else if(fx.type==='halo'){
+        const rad=(fx.r0||40)+((fx.r1||240)-(fx.r0||40))*prog;
+        ctx.strokeStyle=`rgba(${fx.color||'200,150,255'},${0.25*(1-prog)})`;
+        ctx.lineWidth=8*((scaleX+scaleY)/2);
+        ctx.beginPath();
+        ctx.arc(fx.x*scaleX, fx.y*scaleY, rad*((scaleX+scaleY)/2),0,Math.PI*2);
+        ctx.stroke();
+      }
+      ctx.restore();
+    }
+    for(const af of reaperAfterimages){
+      const life=af.life||600;
+      const prog=Math.max(0, Math.min(1, (now-af.t0)/life));
+      const alpha=(af.emerge?prog:1-prog)*0.4;
+      const scale=(af.scale||1)*(1+(af.emerge?0.2*prog:0));
+      ctx.save();
+      ctx.globalCompositeOperation='lighter';
+      ctx.translate(af.x*scaleX, af.y*scaleY);
+      ctx.scale(scale, scale);
+      ctx.globalAlpha=alpha;
+      ctx.fillStyle='rgba(200,150,255,0.6)';
+      ctx.beginPath();
+      ctx.ellipse(0,0, reaperBoss?reaperBoss.w*0.28*((scaleX+scaleY)/2):70*((scaleX+scaleY)/2), reaperBoss?reaperBoss.h*0.36*((scaleX+scaleY)/2):90*((scaleX+scaleY)/2),0,0,Math.PI*2);
+      ctx.fill();
+      ctx.restore();
+    }
+    if(reaperBoss && (reaperPhase==='active' || reaperPhase==='intro' || reaperPhase==='dying')){
+      drawReaperBoss(reaperBoss, now);
+    }else if(reaperPhase==='intro' && reaperAnchor){
+      const cx=(reaperAnchor.x+reaperAnchor.w/2)*scaleX;
+      const cy=(reaperAnchor.y+reaperAnchor.h+80)*scaleY;
+      const rad=Math.max(reaperAnchor.w, reaperAnchor.h)*1.3*((scaleX+scaleY)/2);
+      ctx.save();
+      ctx.globalCompositeOperation='lighter';
+      const g=ctx.createRadialGradient(cx,cy,0,cx,cy,rad);
+      g.addColorStop(0,'rgba(200,140,255,0.18)');
+      g.addColorStop(1,'rgba(200,140,255,0)');
+      ctx.fillStyle=g;
+      ctx.beginPath(); ctx.arc(cx,cy,rad,0,Math.PI*2); ctx.fill();
+      ctx.restore();
+    }
+    if(reaperTargetHighlightUntil && now<reaperTargetHighlightUntil){
+      const bounds=getReaperBounds();
+      if(bounds){
+        const a=Math.max(0, Math.min(1,(reaperTargetHighlightUntil-now)/600));
+        ctx.save();
+        ctx.globalCompositeOperation='lighter';
+        ctx.strokeStyle=`rgba(255,160,230,${0.6*a})`;
+        ctx.lineWidth=4;
+        drawRoundedRect(bounds.x-6,bounds.y-6,bounds.w+12,bounds.h+12,16);
+        ctx.stroke();
+        ctx.restore();
+      }
+    }
+  }
+
+  function drawReaperMarquee(){
+    if(!reaperMarquee) return;
+    const now=performance.now();
+    const {start, fadeStart, end, text} = reaperMarquee;
+    const style=reaperMarquee.style||'marquee';
+    if(now>=end){ reaperMarquee=null; return; }
+    let alpha=1;
+    if(style!=='victorySolid' && now>fadeStart){ alpha = Math.max(0, 1 - (now - fadeStart)/(end - fadeStart||1)); }
+    const scaleAvg=(scaleX+scaleY)/2;
+    const textScale=Math.max(0.6, scaleAvg);
+    const areaHeight=56;
+    const top=Math.max(12, layout().top - areaHeight - 14);
+    const x=40;
+    const width=1100-80;
+    const radius=18;
+    ctx.save();
+    ctx.globalAlpha=alpha;
+    drawRoundedRect(x, top, width, areaHeight, radius);
+    if(style==='victorySolid'){
+      const grad=ctx.createLinearGradient(x*scaleX, top*scaleY, x*scaleX, (top+areaHeight)*scaleY);
+      grad.addColorStop(0,'rgba(46,32,84,0.96)');
+      grad.addColorStop(1,'rgba(18,18,54,0.96)');
+      ctx.fillStyle=grad;
+      ctx.fill();
+      ctx.strokeStyle='rgba(255,210,230,0.75)';
+      ctx.lineWidth=2.2;
+      drawRoundedRect(x, top, width, areaHeight, radius);
+      ctx.stroke();
+      ctx.fillStyle='#ffe9fa';
+      const fontSize=Math.max(24, Math.round(30*textScale));
+      ctx.font=`${fontSize}px 'Playfair Display','Noto Sans TC',serif`;
+      ctx.textAlign='center';
+      ctx.textBaseline='middle';
+      ctx.shadowColor='rgba(255,190,230,0.6)';
+      ctx.shadowBlur=18*textScale;
+      ctx.fillText(text, (x+width/2)*scaleX, (top+areaHeight/2)*scaleY);
+      ctx.shadowBlur=0;
+    }else{
+      const grad=ctx.createLinearGradient(x*scaleX, top*scaleY, x*scaleX, (top+areaHeight)*scaleY);
+      grad.addColorStop(0,'rgba(34,26,70,0.92)');
+      grad.addColorStop(1,'rgba(20,16,46,0.94)');
+      ctx.fillStyle=grad;
+      ctx.fill();
+      ctx.strokeStyle='rgba(200,180,255,0.85)';
+      ctx.lineWidth=2;
+      drawRoundedRect(x, top, width, areaHeight, radius);
+      ctx.stroke();
+      const innerX=x+12;
+      const innerY=top+6;
+      const innerW=width-24;
+      const innerH=areaHeight-12;
+      drawRoundedRect(innerX, innerY, innerW, innerH, radius-6);
+      ctx.save();
+      ctx.clip();
+      ctx.fillStyle='#fef7ff';
+      const fontSize=Math.max(18, Math.round(24*textScale));
+      ctx.font=`${fontSize}px 'Noto Sans TC','Playfair Display',sans-serif`;
+      ctx.textAlign='center';
+      ctx.textBaseline='middle';
+      ctx.shadowColor='rgba(200,160,255,0.5)';
+      ctx.shadowBlur=12*textScale;
+      ctx.fillText(text, (innerX+innerW/2)*scaleX, (innerY+innerH/2)*scaleY);
+      ctx.restore();
+    }
+    ctx.restore();
+  }
+
+  function drawReaperHPBar(){
+    if(!reaperBoss || (reaperPhase!=='active' && reaperPhase!=='dying')) return;
+    const bounds=getReaperBounds();
+    if(!bounds) return;
+    const barW=200;
+    const barH=18;
+    const x=1100 - barW - 40;
+    const y=bounds.y + bounds.h/2 - barH/2;
+    const ratio=Math.max(0, Math.min(1, reaperBoss.hp/reaperBoss.maxHp));
+    ctx.save();
+    ctx.globalCompositeOperation='lighter';
+    drawRoundedRect(x-10, y-18, barW+20, barH+36, 16);
+    const bgGrad=ctx.createLinearGradient(x*scaleX, (y-6)*scaleY, x*scaleX, (y+barH+6)*scaleY);
+    bgGrad.addColorStop(0,'rgba(40,26,70,0.85)');
+    bgGrad.addColorStop(1,'rgba(26,16,50,0.9)');
+    ctx.fillStyle=bgGrad;
+    ctx.fillRect((x-6)*scaleX,(y-6)*scaleY,(barW+12)*scaleX,(barH+12)*scaleY);
+    const hpGrad=ctx.createLinearGradient(x*scaleX, y*scaleY, (x+barW)*scaleX, (y+barH)*scaleY);
+    hpGrad.addColorStop(0,'rgba(255,120,200,0.95)');
+    hpGrad.addColorStop(1,'rgba(200,120,255,0.95)');
+    ctx.fillStyle='rgba(0,0,0,0.45)';
+    ctx.fillRect(x*scaleX, y*scaleY, barW*scaleX, barH*scaleY);
+    ctx.fillStyle=hpGrad;
+    ctx.fillRect(x*scaleX, y*scaleY, (barW*ratio)*scaleX, barH*scaleY);
+    ctx.strokeStyle='rgba(255,200,240,0.8)';
+    ctx.lineWidth=2;
+    ctx.strokeRect(x*scaleX, y*scaleY, barW*scaleX, barH*scaleY);
+    ctx.fillStyle='#f8eaff';
+    ctx.font=`${Math.round(16*((scaleX+scaleY)/2))}px 'Playfair Display',serif`;
+    ctx.textAlign='center';
+    ctx.textBaseline='bottom';
+    ctx.fillText('BOSS 暗黑死神', (x+barW/2)*scaleX, (y-8)*scaleY);
+    ctx.fillStyle='rgba(240,220,255,0.85)';
+    ctx.textBaseline='top';
+    ctx.fillText(`${reaperBoss.hp}/${reaperBoss.maxHp}`, (x+barW/2)*scaleX, (y+barH+4)*scaleY);
+    ctx.restore();
+  }
+
+  function drawReaperHUD(){
+    drawReaperMarquee();
+    drawReaperHPBar();
+  }
+
+  function isSpecialBossActive(){
+    return isSpaceBossActive() || isReaperActive();
+  }
+
+  function activeBossCenter(){
+    if(isSpaceBossActive()) return {x:spaceBoss.x, y:spaceBoss.y, type:'space'};
+    if(isReaperActive() && reaperBoss) return {x:reaperBoss.x, y:reaperBoss.y, type:'reaper'};
+    return null;
+  }
+
+  function getActiveBossBounds(){
+    if(isSpaceBossActive()) return getSpaceBossBounds();
+    if(isReaperActive()) return getReaperBounds();
+    return null;
+  }
+
+  function activeBossImpactPoint(fromX, fromY){
+    if(isSpaceBossActive()) return spaceBossImpactPoint(fromX, fromY);
+    if(isReaperActive()) return reaperImpactPoint(fromX, fromY);
+    return {x:fromX, y:fromY};
+  }
+
+  function damageActiveBoss(amount=1, source='generic', impact){
+    if(isSpaceBossActive()) return damageSpaceBoss(amount, source, impact);
+    if(isReaperActive()) return damageReaperBoss(amount, source, impact);
+    return false;
+  }
+
+  function circleIntersectsActiveBoss(cx, cy, radius){
+    if(isSpaceBossActive()) return circleIntersectsSpaceBoss(cx, cy, radius);
+    if(isReaperActive()) return circleIntersectsReaper(cx, cy, radius);
+    return false;
+  }
+
+  function activeBossClampPoint(x, y){
+    const bounds=getActiveBossBounds();
+    if(!bounds) return {x, y};
+    return {
+      x: Math.max(bounds.x, Math.min(x, bounds.x + bounds.w)),
+      y: Math.max(bounds.y, Math.min(y, bounds.y + bounds.h))
+    };
+  }
   // === 修正：格點對齊地揭示底圖，避免黑洞與浮點誤差 ===
   function revealBrickArea(brick){
     const L = layout();
@@ -3275,6 +3947,33 @@ function generateLevel(lv, L){
             if(c>=bx && c<=bx+1 && r>=by && r<=by+1) continue;
             const explosive=Math.random()<GAME_CONFIG.bricks.explosiveChance;
             addBrick(bricks, xAt(c), yAt(r), brickW, brickH, {hp:baseHP, colorIdx:(r%4), explosive});
+          }
+        }
+        return;
+      }else if(lv===10){
+        const bx = Math.floor(cols/2)-1;
+        const by = 0;
+        const w = brickW*2 + pad;
+        const h = brickH*2 + pad;
+        const placeholderIndex=bricks.length;
+        addBrick(bricks, xAt(bx), yAt(by), w, h, {hp:1, colorIdx:0, boss:true, face:'影', strong:true, unbreakable:true});
+        reaperPlaceholder = bricks[placeholderIndex];
+        if(reaperPlaceholder){
+          reaperPlaceholder.hp=0;
+          reaperPlaceholder.placeholderBoss=true;
+        }
+        for(let r=0;r<rows;r++){
+          for(let c=0;c<cols;c++){
+            if(c>=bx && c<=bx+1 && r>=by && r<=by+1) continue;
+            const isTopShield = (r===0 && (c%2===0));
+            if(isTopShield){
+              addBrick(bricks, xAt(c), yAt(r), brickW, brickH, {unbreakable:true});
+              continue;
+            }
+            const moving = (r%3===0 && c%4===0);
+            const hpBoost = baseHP + (r%2===0?1:0);
+            const explosive = (!moving && Math.random()<GAME_CONFIG.bricks.explosiveChance*0.6);
+            addBrick(bricks, xAt(c), yAt(r), brickW, brickH, {hp:hpBoost, colorIdx:(r%4), moving, vx:moving?((Math.random()<0.5?-1:1)*0.7):0, explosive});
           }
         }
         return;
@@ -3446,8 +4145,10 @@ function generateLevel(lv, L){
         spawnParticles(bx,by,'#ffdd99',14,1.7,2.6,3);
       }
     }
-    if(isSpaceBossActive() && circleIntersectsSpaceBoss(cx,cy,radius)){
-      damageSpaceBoss(1,'fire',{x:spaceBoss.x,y:spaceBoss.y});
+    if(circleIntersectsActiveBoss(cx,cy,radius)){
+      const center=activeBossCenter();
+      const impact=center?{x:center.x,y:center.y}:{x:cx,y:cy};
+      damageActiveBoss(1,'fire',impact);
     }
     spawnParticles(cx,cy,'#ffbb55',24,2.1,3.2,4); updateHUD(); playSFX('explosion');
   }
@@ -3469,8 +4170,10 @@ function generateLevel(lv, L){
         spawnParticles(bx,by,'#ffdd99',20,1.8,2.8,3.5);
       }
     }
-    if(isSpaceBossActive() && circleIntersectsSpaceBoss(cx,cy,radius)){
-      damageSpaceBoss(1,'fire',{x:spaceBoss.x,y:spaceBoss.y});
+    if(circleIntersectsActiveBoss(cx,cy,radius)){
+      const center=activeBossCenter();
+      const impact=center?{x:center.x,y:center.y}:{x:cx,y:cy};
+      damageActiveBoss(1,'fire',impact);
     }
     fireExplosions.push({x:cx,y:cy,r:radius,t0:performance.now(),life:400});
     spawnParticles(cx,cy,'#ff5500',60,2.6,3.8,4.5);
@@ -3701,7 +4404,11 @@ function generateLevel(lv, L){
           } else keep.push(b);
         }
         bricks=keep; screenShake=6; playSFX('phoenix'); updateHUD();
-        if(isSpaceBossActive()){ damageSpaceBoss(1,'phoenix',{x:spaceBoss.x,y:spaceBoss.y}); }
+        if(isSpecialBossActive()){
+          const center=activeBossCenter();
+          const impact=center?{x:center.x,y:center.y}:null;
+          damageActiveBoss(1,'phoenix',impact);
+        }
       } else if(type==='NINE'){ if(nineCatEaten>=2) return; lives=9; nineCatEaten++; updateHUD(); spawnParticles(550,350,'#ffd',40,2.2,3.5,4); beep(880,0.1,0.06); }
       return;
     }
@@ -4430,8 +5137,9 @@ function generateLevel(lv, L){
           }
         }
       }
-      if(isSpaceBossActive() && circleIntersectsSpaceBoss(P.x,P.y,P.radius)){
-        damageSpaceBoss(1,'plasma',{x:spaceBoss.x,y:spaceBoss.y});
+      if(circleIntersectsActiveBoss(P.x,P.y,P.radius)){
+        const impact=activeBossClampPoint(P.x, P.y);
+        damageActiveBoss(1,'plasma',impact);
       }
     } ctx.restore(); }
 
@@ -4499,6 +5207,7 @@ function generateLevel(lv, L){
     }
 
     drawSpaceBossLayer();
+    drawReaperLayer();
     drawPlasmas(); drawHoly(); drawPhoenix(); drawSwords();
 
       // Boss wind-up glow
@@ -4687,6 +5396,7 @@ function generateLevel(lv, L){
       const a=Math.max(0, Math.min(1, P.life/500)); ctx.fillStyle=P.color||`rgba(255,220,180,${a*0.6})`; ctx.beginPath(); ctx.arc(P.x*scaleX,P.y*scaleY,P.size*((scaleX+scaleY)/2),0,Math.PI*2); ctx.fill(); }
 
     drawSpaceBossHUD();
+    drawReaperHUD();
 
     // 倒數提示
     if(countdownShow>0){
@@ -4724,7 +5434,7 @@ function generateLevel(lv, L){
     if(screenShake>0){ ctx.restore(); }
   }
 
-  function drawSwords(){ const now=performance.now(); const pr=paddleRect(); for(let i=swords.length-1;i>=0;i--){ const s=swords[i]; if(s.state==='wander'){ s.x+=s.vx; s.y+=s.vy; if(s.x<20||s.x>1080) s.vx*=-1; if(s.y<500||s.y>680) s.vy*=-1; if(!buffs.SWORD.active){ s.state='gather'; s.t0=now; s.tx=pr.x+pr.w/2+ (i-swords.length/2)*20; s.ty=pr.y-40; } } else if(s.state==='gather'){ const prog=Math.min(1,(now-s.t0)/2000); s.x += (s.tx-s.x)*0.15; s.y += (s.ty-s.y)*0.15; if(prog>=1){ s.state='ready'; } } else if(s.state==='fire'){ s.x+=s.vx; s.y+=s.vy; const idx=s.target; if(idx==='boss'){ const bounds=getSpaceBossBounds(); if(!isSpaceBossActive() || !bounds){ swords.splice(i,1); continue; } if(s.x>bounds.x && s.x<bounds.x+bounds.w && s.y>bounds.y && s.y<bounds.y+bounds.h){ playSFX('sword'); damageSpaceBoss(1,'sword',{x:s.x,y:s.y}); swords.splice(i,1); continue; } } else { const bk=bricks[idx]; if(bk && s.x>bk.x && s.x<bk.x+bk.w && s.y>bk.y && s.y<bk.y+bk.h){ playSFX('sword'); damageBrick(idx,3,'none'); swords.splice(i,1); continue; } } if(s.x<0||s.x>1100||s.y<0||s.y>700){ swords.splice(i,1); continue; } }
+  function drawSwords(){ const now=performance.now(); const pr=paddleRect(); for(let i=swords.length-1;i>=0;i--){ const s=swords[i]; if(s.state==='wander'){ s.x+=s.vx; s.y+=s.vy; if(s.x<20||s.x>1080) s.vx*=-1; if(s.y<500||s.y>680) s.vy*=-1; if(!buffs.SWORD.active){ s.state='gather'; s.t0=now; s.tx=pr.x+pr.w/2+ (i-swords.length/2)*20; s.ty=pr.y-40; } } else if(s.state==='gather'){ const prog=Math.min(1,(now-s.t0)/2000); s.x += (s.tx-s.x)*0.15; s.y += (s.ty-s.y)*0.15; if(prog>=1){ s.state='ready'; } } else if(s.state==='fire'){ s.x+=s.vx; s.y+=s.vy; const idx=s.target; if(idx==='boss'){ const bounds=getActiveBossBounds(); if(!isSpecialBossActive() || !bounds){ swords.splice(i,1); continue; } if(s.x>bounds.x && s.x<bounds.x+bounds.w && s.y>bounds.y && s.y<bounds.y+bounds.h){ playSFX('sword'); damageActiveBoss(1,'sword',{x:s.x,y:s.y}); swords.splice(i,1); continue; } } else { const bk=bricks[idx]; if(bk && s.x>bk.x && s.x<bk.x+bk.w && s.y>bk.y && s.y<bk.y+bk.h){ playSFX('sword'); damageBrick(idx,3,'none'); swords.splice(i,1); continue; } } if(s.x<0||s.x>1100||s.y<0||s.y>700){ swords.splice(i,1); continue; } }
       ctx.save();
       ctx.translate(s.x*scaleX, s.y*scaleY);
       ctx.rotate(Math.atan2(s.vy||0.1, s.vx||0.1));
@@ -4752,8 +5462,9 @@ function generateLevel(lv, L){
           if(idx!=null){
             let tx=null, ty=null;
             if(idx==='boss'){
-              if(isSpaceBossActive()){
-                tx=spaceBoss.x; ty=spaceBoss.y;
+              if(isSpecialBossActive()){
+                const center=activeBossCenter();
+                if(center){ tx=center.x; ty=center.y; }
                 highlightSpaceBossTarget();
               }
             }else{
@@ -4777,7 +5488,7 @@ function generateLevel(lv, L){
 
   function randomBrick(includeBoss=false){
     const arr=bricks.map((b,i)=>({b,i})).filter(x=>canDestroyBrick(x.b));
-    if(includeBoss && isSpaceBossActive()){ arr.push({boss:true}); }
+    if(includeBoss && isSpecialBossActive()){ arr.push({boss:true}); }
     if(!arr.length) return null;
     const r=arr[Math.floor(Math.random()*arr.length)];
     return r.boss ? 'boss' : r.i;
@@ -4866,6 +5577,7 @@ function generateLevel(lv, L){
     }
     computePaddleWidth(); updateBuffBadges();
     updateSpaceBoss();
+    updateReaperBoss();
 
     // 劇毒磚持續扣血
     for(let i=bricks.length-1;i>=0;i--){
@@ -4990,23 +5702,24 @@ function generateLevel(lv, L){
             const d=dx*dx+dy*dy;
             if(d>best){ best=d; target={type:'brick', idx:i, x:bk.x+bk.w/2, y:bk.y+bk.h/2}; }
           }
-          if(isSpaceBossActive()){
-            const dx=spaceBoss.x - s.x;
-            const dy=spaceBoss.y - s.y;
+          const bossCenter = isSpecialBossActive() ? activeBossCenter() : null;
+          if(bossCenter){
+            const dx=bossCenter.x - s.x;
+            const dy=bossCenter.y - s.y;
             const d=dx*dx+dy*dy;
             if(d>best){
               best=d;
-              target={type:'boss', x:spaceBoss.x, y:spaceBoss.y};
+              target={type:'boss', x:bossCenter.x, y:bossCenter.y};
               highlightSpaceBossTarget();
             }
           }
           if(target){
-            const impact = target.type==='boss' ? spaceBossImpactPoint(s.x,s.y) : {x:target.x, y:target.y};
+            const impact = target.type==='boss' ? activeBossImpactPoint(s.x,s.y) : {x:target.x, y:target.y};
             laserBeams.push({x1:s.x,y1:s.y,x2:impact.x,y2:impact.y,until:now+200});
             laserImpacts.push({x:impact.x, y:impact.y, t0:now, tEnd:now+320});
             spawnParticles(impact.x,impact.y,'rgba(160,255,200,0.9)',10,1.8,2.2,2.6);
             if(target.type==='boss'){
-              damageSpaceBoss(1,'laser',impact);
+              damageActiveBoss(1,'laser',impact);
             }else{
               destroyBrick(target.idx,'laser');
             }
@@ -5057,22 +5770,22 @@ function generateLevel(lv, L){
           break;
         }
       }
-      if(!removed && isSpaceBossActive()){
-        const bounds=getSpaceBossBounds();
+      if(!removed && isSpecialBossActive()){
+        const bounds=getActiveBossBounds();
         if(bounds && bl.x>bounds.x && bl.x<bounds.x+bounds.w && bl.y>bounds.y && bl.y<bounds.y+bounds.h){
           spawnParticles(bl.x, bl.y, '#ffdd77', 8, 1.6, 3.2, 2.5);
           playSFX('gatlingHit');
-          damageSpaceBoss(1,'gatling',{x:bl.x,y:bl.y});
+          damageActiveBoss(1,'gatling',{x:bl.x,y:bl.y});
           gatlingBullets.splice(i,1);
         }
       }
     }
 
-    if(stormTurret){ if(now>=stormTurret.fireAt){ if(stormTurret.shots<=0){ stormTurret=null; buffs.STORM.active=false; } else if(now-stormTurret.lastShot>=200){ const idx=randomBrick(true); if(idx!=null){ if(idx==='boss' && isSpaceBossActive()){ const impact=spaceBossImpactPoint(stormTurret.x,stormTurret.y); highlightSpaceBossTarget(); laserBeams.push({x1:stormTurret.x,y1:stormTurret.y,x2:impact.x,y2:impact.y,until:now+200}); laserImpacts.push({x:impact.x,y:impact.y,t0:now,tEnd:now+320}); damageSpaceBoss(1,'laser',impact); } else { const t=bricks[idx]; if(t){ const tx=t.x+t.w/2, ty=t.y+t.h/2; laserBeams.push({x1:stormTurret.x,y1:stormTurret.y,x2:tx,y2:ty,until:now+200}); laserImpacts.push({x:tx,y:ty,t0:now,tEnd:now+320}); destroyBrick(idx,'laser'); } } stormTurret.shots--; stormTurret.lastShot=now; } } } }
+    if(stormTurret){ if(now>=stormTurret.fireAt){ if(stormTurret.shots<=0){ stormTurret=null; buffs.STORM.active=false; } else if(now-stormTurret.lastShot>=200){ const idx=randomBrick(true); if(idx!=null){ if(idx==='boss' && isSpecialBossActive()){ const impact=activeBossImpactPoint(stormTurret.x,stormTurret.y); highlightSpaceBossTarget(); laserBeams.push({x1:stormTurret.x,y1:stormTurret.y,x2:impact.x,y2:impact.y,until:now+200}); laserImpacts.push({x:impact.x,y:impact.y,t0:now,tEnd:now+320}); damageActiveBoss(1,'laser',impact); } else { const t=bricks[idx]; if(t){ const tx=t.x+t.w/2, ty=t.y+t.h/2; laserBeams.push({x1:stormTurret.x,y1:stormTurret.y,x2:tx,y2:ty,until:now+200}); laserImpacts.push({x:tx,y:ty,t0:now,tEnd:now+320}); destroyBrick(idx,'laser'); } } stormTurret.shots--; stormTurret.lastShot=now; } } } }
 
-    if(buffs.BLACKHOLE.active && now>buffs.BLACKHOLE.until){ const d=Math.min(8,buffs.BLACKHOLE.deaths||0); const dmg=1+(d/8)*(40-1); const rad=200+(d/8)*(800-200); const pr=paddleRect(); const cx=pr.x+pr.w/2, cy=pr.y-rad; blackHoles.push({x:cx,y:cy,r:rad,until:now+3000}); for(let i=bricks.length-1;i>=0;i--){ const bk=bricks[i]; const bx=bk.x+bk.w/2, by=bk.y+bk.h/2; if(Math.hypot(bx-cx,by-cy)<=rad){ damageBrick(i,dmg,'none'); } } if(isSpaceBossActive() && circleIntersectsSpaceBoss(cx,cy,rad)){ damageSpaceBoss(1,'blackhole',{x:spaceBoss.x,y:spaceBoss.y}); } playSFX('blackhole'); buffs.BLACKHOLE.active=false; }
+    if(buffs.BLACKHOLE.active && now>buffs.BLACKHOLE.until){ const d=Math.min(8,buffs.BLACKHOLE.deaths||0); const dmg=1+(d/8)*(40-1); const rad=200+(d/8)*(800-200); const pr=paddleRect(); const cx=pr.x+pr.w/2, cy=pr.y-rad; blackHoles.push({x:cx,y:cy,r:rad,until:now+3000}); for(let i=bricks.length-1;i>=0;i--){ const bk=bricks[i]; const bx=bk.x+bk.w/2, by=bk.y+bk.h/2; if(Math.hypot(bx-cx,by-cy)<=rad){ damageBrick(i,dmg,'none'); } } if(circleIntersectsActiveBoss(cx,cy,rad)){ const impact=activeBossCenter(); damageActiveBoss(1,'blackhole',impact?{x:impact.x,y:impact.y}:{x:cx,y:cy}); } playSFX('blackhole'); buffs.BLACKHOLE.active=false; }
 
-    if(buffs.ANNIHIL.active && now>=buffs.ANNIHIL.next){ let cand=bricks.filter(b=>canDestroyBrick(b)&&!b.boss); if(!cand.length) cand=bricks.filter(b=>canDestroyBrick(b)); if(cand.length){ const target=cand[Math.floor(Math.random()*cand.length)]; const idx=bricks.indexOf(target); destroyBrick(idx,'annihil'); } else if(isSpaceBossActive()){ damageSpaceBoss(1,'annihil',{x:spaceBoss.x,y:spaceBoss.y}); } buffs.ANNIHIL.next+=1000; }
+    if(buffs.ANNIHIL.active && now>=buffs.ANNIHIL.next){ let cand=bricks.filter(b=>canDestroyBrick(b)&&!b.boss); if(!cand.length) cand=bricks.filter(b=>canDestroyBrick(b)); if(cand.length){ const target=cand[Math.floor(Math.random()*cand.length)]; const idx=bricks.indexOf(target); destroyBrick(idx,'annihil'); } else if(isSpecialBossActive()){ const center=activeBossCenter(); damageActiveBoss(1,'annihil',center?{x:center.x,y:center.y}:null); } buffs.ANNIHIL.next+=1000; }
 
     // 全局速度倍率（GODSPEED 時忽略其它）
     function effectiveMul(){
@@ -5213,8 +5926,9 @@ function generateLevel(lv, L){
           // 取最近/中距離/最遠
           const src={x:b.x,y:b.y};
           const candidates = bricks.map((bk,idx)=>({idx, type:'brick', d: (bk.x+bk.w/2-src.x)**2 + (bk.y+bk.h/2-src.y)**2 })).sort((a,b)=>a.d-b.d);
-          if(isSpaceBossActive()){
-            const d = (spaceBoss.x-src.x)**2 + (spaceBoss.y-src.y)**2;
+          const bossCenter = isSpecialBossActive() ? activeBossCenter() : null;
+          if(bossCenter){
+            const d = (bossCenter.x-src.x)**2 + (bossCenter.y-src.y)**2;
             candidates.push({idx:'boss', type:'boss', d});
             candidates.sort((a,b)=>a.d-b.d);
           }
@@ -5239,11 +5953,12 @@ function generateLevel(lv, L){
           }
           let best=null;
           for(const t of bricks){ if(t.unbreakable) continue; const iso=neighborCount(t); const d=Math.hypot((t.x+t.w/2)-b.x,(t.y+t.h/2)-b.y); const score=iso*1000 + d; if(best==null || score<best.score) best={t,score,type:'brick'}; }
-          if(!best && isSpaceBossActive()){
+          const bossTarget = isSpecialBossActive() ? activeBossCenter() : null;
+          if(!best && bossTarget){
             best={type:'boss', score:-Infinity};
           }
-          const targetX = best? (best.type==='boss'? spaceBoss.x : best.t.x+best.t.w/2) : (1100/2);
-          const targetY = best? (best.type==='boss'? spaceBoss.y : best.t.y+best.t.h/2) : (layout().top);
+          const targetX = best? (best.type==='boss'? (bossTarget?bossTarget.x:1100/2) : best.t.x+best.t.w/2) : (1100/2);
+          const targetY = best? (best.type==='boss'? (bossTarget?bossTarget.y:layout().top) : best.t.y+best.t.h/2) : (layout().top);
           const sp=Math.hypot(b.vx,b.vy); const ang=Math.atan2(targetY-b.y, targetX-b.x); b.vx=Math.cos(ang)*sp; b.vy=Math.sin(ang)*sp;
 
           if(best){
@@ -5281,7 +5996,7 @@ function generateLevel(lv, L){
         // 特效觸發
         if(buffs.PLASMA.active){ const cfg=GAME_CONFIG.powers.PLASMA.plasma; const ang=Math.random()*Math.PI*2; plasmas.push({x:bk.x+bk.w/2,y:bk.y+bk.h/2,vx:Math.cos(ang)*cfg.drift,vy:Math.sin(ang)*cfg.drift,until:now+cfg.lifeMs,radius:cfg.radius,phase:Math.random()*Math.PI*2}); playSFX('plasma'); }
         if(buffs.FREEZE.active && (b.freeze.state==='idle' || !b.freeze.state)){ const f=GAME_CONFIG.powers.FREEZE.freeze; b.freeze.state = 'delay'; b.freeze.t0 = now; b.freeze.delay = f.delayMs; b.freeze.stop = f.stopMs; b.freeze.oldVX = b.vx; b.freeze.oldVY = b.vy; }
-        if(buffs.HOLY.active){ playSFX('holy'); holyFlashes.push({x:bk.x+bk.w/2, y:bk.y+bk.h/2, until:now+350}); for(let i=bricks.length-1;i>=0;i--){ const t=bricks[i]; const sameRow=Math.abs(t.y-bk.y)<1; const sameCol=Math.abs(t.x-bk.x)<1; if(sameRow||sameCol){ destroyBrick(i,'none'); } } if(isSpaceBossActive()){ const bounds=getSpaceBossBounds(); const rowY=bk.y+bk.h/2; const colX=bk.x+bk.w/2; let bossHit=false; if(bounds && rowY>=bounds.y && rowY<=bounds.y+bounds.h){ damageSpaceBoss(1,'holy',{x:spaceBoss.x,y:rowY}); bossHit=true; } if(bounds && !bossHit && colX>=bounds.x && colX<=bounds.x+bounds.w){ damageSpaceBoss(1,'holy',{x:colX,y:spaceBoss.y}); } } screenShake=Math.max(screenShake,4); }
+        if(buffs.HOLY.active){ playSFX('holy'); holyFlashes.push({x:bk.x+bk.w/2, y:bk.y+bk.h/2, until:now+350}); for(let i=bricks.length-1;i>=0;i--){ const t=bricks[i]; const sameRow=Math.abs(t.y-bk.y)<1; const sameCol=Math.abs(t.x-bk.x)<1; if(sameRow||sameCol){ destroyBrick(i,'none'); } } if(isSpecialBossActive()){ const bounds=getActiveBossBounds(); const rowY=bk.y+bk.h/2; const colX=bk.x+bk.w/2; let bossHit=false; if(bounds && rowY>=bounds.y && rowY<=bounds.y+bounds.h){ const cx=bounds.x+bounds.w/2; damageActiveBoss(1,'holy',{x:cx,y:rowY}); bossHit=true; } if(bounds && !bossHit && colX>=bounds.x && colX<=bounds.x+bounds.w){ const cy=bounds.y+bounds.h/2; damageActiveBoss(1,'holy',{x:colX,y:cy}); } } screenShake=Math.max(screenShake,4); }
         if(buffs.CHAIN.active){ bk.lockedUntil = now + GAME_CONFIG.powers.CHAIN.chain.lockMs; }
         if(buffs.HELL.active){ blackHoles.push({x:bk.x+bk.w/2,y:bk.y+bk.h/2,r:40,until:now+GAME_CONFIG.powers.HELL.hell.haloMs}); playSFX('blackhole'); destroyNeighbors(hit); destroyBrick(hit,'none'); }
         if(buffs.POISON.active){ bk.poisonUntil = now + (GAME_CONFIG.powers.POISON.durationMs||12000); bk.poisonTick = now + (GAME_CONFIG.powers.POISON.poison?.tickMs||2000); }
@@ -5321,31 +6036,32 @@ function generateLevel(lv, L){
         beep(520+Math.random()*200,0.03,0.05);
       }
 
-      if(!collidedWithBrick && spaceBossPhase==='active' && spaceBoss){
-        const sb=spaceBoss;
-        const halfW=sb.w/2, halfH=sb.h/2;
-        const rx=sb.x-halfW, ry=sb.y-halfH;
-        if(b.x+r>rx && b.x-r<rx+sb.w && b.y+r>ry && b.y-r<ry+sb.h){
-          const oL=(b.x+r)-rx, oR=(rx+sb.w)-(b.x-r), oT=(b.y+r)-ry, oB=(ry+sb.h)-(b.y-r);
-          const m=Math.min(oL,oR,oT,oB);
-          if(!inRampage && !b.piercing){
-            if(m===oL){ b.x=rx-r; b.vx=-Math.abs(b.vx)||-4; }
-            else if(m===oR){ b.x=rx+sb.w+r; b.vx=Math.abs(b.vx)||4; }
-            else if(m===oT){ b.y=ry-r; b.vy=-Math.abs(b.vy)||-4; }
-            else { b.y=ry+sb.h+r; b.vy=Math.abs(b.vy)||4; }
-          }else{
-            if(m===oL){ b.x=rx-r; b.vx=Math.abs(b.vx)||4; }
-            else if(m===oR){ b.x=rx+sb.w+r; b.vx=-Math.abs(b.vx)||-4; }
-            else if(m===oT){ b.y=ry-r; b.vy=Math.abs(b.vy)||4; }
-            else { b.y=ry+sb.h+r; b.vy=-Math.abs(b.vy)||-4; }
-            b.piercing=true;
+      if(!collidedWithBrick && isSpecialBossActive()){
+        const bounds=getActiveBossBounds();
+        if(bounds){
+          const rx=bounds.x, ry=bounds.y, rw=bounds.w, rh=bounds.h;
+          if(b.x+r>rx && b.x-r<rx+rw && b.y+r>ry && b.y-r<ry+rh){
+            const oL=(b.x+r)-rx, oR=(rx+rw)-(b.x-r), oT=(b.y+r)-ry, oB=(ry+rh)-(b.y-r);
+            const m=Math.min(oL,oR,oT,oB);
+            if(!inRampage && !b.piercing){
+              if(m===oL){ b.x=rx-r; b.vx=-Math.abs(b.vx)||-4; }
+              else if(m===oR){ b.x=rx+rw+r; b.vx=Math.abs(b.vx)||4; }
+              else if(m===oT){ b.y=ry-r; b.vy=-Math.abs(b.vy)||-4; }
+              else { b.y=ry+rh+r; b.vy=Math.abs(b.vy)||4; }
+            }else{
+              if(m===oL){ b.x=rx-r; b.vx=Math.abs(b.vx)||4; }
+              else if(m===oR){ b.x=rx+rw+r; b.vx=-Math.abs(b.vx)||-4; }
+              else if(m===oT){ b.y=ry-r; b.vy=Math.abs(b.vy)||4; }
+              else { b.y=ry+rh+r; b.vy=-Math.abs(b.vy)||-4; }
+              b.piercing=true;
+            }
+            const impactX = Math.max(rx, Math.min(b.x, rx+rw));
+            const impactY = Math.max(ry, Math.min(b.y, ry+rh));
+            spawnParticles(impactX, impactY, '#b8d6ff', 20, 1.4, 2.4, 2.2);
+            fireCollide();
+            damageActiveBoss(1,'ball',{x:impactX,y:impactY});
+            collidedWithBrick=true;
           }
-          const impactX = Math.max(rx, Math.min(b.x, rx+sb.w));
-          const impactY = Math.max(ry, Math.min(b.y, ry+sb.h));
-          spawnParticles(impactX, impactY, '#b8d6ff', 20, 1.4, 2.4, 2.2);
-          fireCollide();
-          damageSpaceBoss(1,'ball',{x:impactX,y:impactY});
-          collidedWithBrick=true;
         }
       }
 
@@ -5363,10 +6079,12 @@ function generateLevel(lv, L){
       if(now>m.lifeUntil){ missiles.splice(i,1); continue; }
       let tx,ty, rect=null;
       if(m.targetType==='boss'){
-        if(!isSpaceBossActive()){ missiles.splice(i,1); continue; }
-        const bounds=getSpaceBossBounds();
+        if(!isSpecialBossActive()){ missiles.splice(i,1); continue; }
+        const bounds=getActiveBossBounds();
+        const center=activeBossCenter();
+        if(!bounds || !center){ missiles.splice(i,1); continue; }
         rect=bounds;
-        tx=spaceBoss.x; ty=spaceBoss.y;
+        tx=center.x; ty=center.y;
       }else{
         const t=bricks[m.targetId];
         if(!t){ missiles.splice(i,1); continue; }
@@ -5385,7 +6103,7 @@ function generateLevel(lv, L){
       (m.trail||(m.trail=[])).push({x:m.x,y:m.y,t:now}); if(m.trail.length>20) m.trail.shift();
       // 命中判定
       if(rect && m.x>rect.x && m.x<rect.x+rect.w && m.y>rect.y && m.y<rect.y+rect.h){
-        if(m.targetType==='boss'){ damageSpaceBoss(1,'missile',{x:m.x,y:m.y}); }
+        if(m.targetType==='boss'){ damageActiveBoss(1,'missile',{x:m.x,y:m.y}); }
         else { destroyBrick(m.targetId,'missile'); }
         missiles.splice(i,1); spawnParticles(m.x,m.y,'#ffbb66',12,1.8,2.2,3);
       }


### PR DESCRIPTION
## Summary
- add shared boss helpers so level 10's Dark Reaper can reuse targeting, impact, and damage utilities
- update explosives, projectiles, buffs, and missiles to recognize either active boss and apply highlights and damage consistently
- extend missile and sword targeting plus boss collision handling to operate on the new reaper boss while keeping space boss behavior intact

## Testing
- No tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc041f32ac83289407200449cb4a88