### PR TITLE
Allow cyclops attack during dragon intro

### DIFF
--- a/index.html
+++ b/index.html
@@ -1857,7 +1857,7 @@ select optgroup { color: #0b1022; }
     const bossLv = (level%5===0)? level : 0;
     if(!bossLv) return;
     if(level===5 && spaceBossPhase!=='inactive') return;
-    if(level===15 && dragonPhase!=='active') return;
+    if(level===15 && (dragonPhase==='dying' || dragonPhase==='defeated' || dragonPhase==='inactive')) return;
     const now=performance.now();
     if(bossLv===5){ if(now>=nextBossAtkA){ spawnLionBeam(); nextBossAtkA = now + 10000; } }
     else if(bossLv===10){ if(now>=nextBossAtkA){ spawnKnightArc(); nextBossAtkA = now + 15000; } }


### PR DESCRIPTION
## Summary
- relax the level 15 boss guard so cyclops columns continue firing while the dragon is awaiting or in its intro sequence

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ce8245d5f083289f490b0e7280742d