### PR TITLE
Refine dragon boss scale and redesign head

### DIFF
--- a/index.html
+++ b/index.html
@@ -4941,8 +4941,8 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
       x:cx,
       y:baseY,
       baseY,
-      w:240,
-      h:150,
+      w:120,
+      h:75,
       hp:DRAGON_MAX_HP,
       maxHp:DRAGON_MAX_HP,
       wingPhase:Math.random()*Math.PI*2,
@@ -5848,41 +5848,45 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
 
     drawDragonHalo(ctx);
 
-    const headGrad=metalGradient(-64,-142,64,72);
+    ctx.save();
+    ctx.translate(0,-6);
+    ctx.scale(0.82,0.76);
+
+    const headGrad=metalGradient(-58,-148,58,66);
     ctx.fillStyle=headGrad;
     ctx.beginPath();
-    ctx.moveTo(-68,26);
-    ctx.lineTo(-94,-18);
-    ctx.quadraticCurveTo(-108,-82,-72,-146);
-    ctx.quadraticCurveTo(-34,-206,-8,-214);
+    ctx.moveTo(-56,22);
+    ctx.lineTo(-82,-18);
+    ctx.quadraticCurveTo(-102,-86,-52,-158);
+    ctx.quadraticCurveTo(-18,-206,-4,-214);
     ctx.lineTo(0,-220);
-    ctx.lineTo(8,-214);
-    ctx.quadraticCurveTo(34,-206,72,-146);
-    ctx.quadraticCurveTo(108,-82,94,-18);
-    ctx.lineTo(68,26);
-    ctx.quadraticCurveTo(24,58,0,62);
-    ctx.quadraticCurveTo(-24,58,-68,26);
+    ctx.lineTo(4,-214);
+    ctx.quadraticCurveTo(18,-206,52,-158);
+    ctx.quadraticCurveTo(102,-86,82,-18);
+    ctx.lineTo(56,22);
+    ctx.quadraticCurveTo(18,50,0,54);
+    ctx.quadraticCurveTo(-18,50,-56,22);
     ctx.closePath();
     ctx.fill();
     ctx.strokeStyle=`rgba(255,240,220,${flash?0.94:0.8})`;
-    ctx.lineWidth=3.2;
+    ctx.lineWidth=2.8;
     ctx.stroke();
 
     // segmented forehead plates with central ridge
     ctx.strokeStyle=`rgba(255,236,210,${flash?0.92:0.74})`;
-    ctx.lineWidth=2.2;
+    ctx.lineWidth=2;
     ctx.beginPath();
-    ctx.moveTo(0,-218);
-    ctx.lineTo(0,20);
+    ctx.moveTo(0,-216);
+    ctx.lineTo(0,18);
     ctx.stroke();
 
     const foreheadSteps=[
-      {y:-188, inset:20},
-      {y:-160, inset:26},
-      {y:-132, inset:32},
-      {y:-104, inset:38}
+      {y:-176, inset:18},
+      {y:-150, inset:24},
+      {y:-126, inset:30},
+      {y:-102, inset:34}
     ];
-    ctx.lineWidth=1.6;
+    ctx.lineWidth=1.5;
     for(const step of foreheadSteps){
       ctx.beginPath();
       ctx.moveTo(-step.inset, step.y);
@@ -5891,22 +5895,22 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
     }
 
     const crownSegments=[
-      {top:-232, mid:-220, base:-206, width:16},
-      {top:-222, mid:-208, base:-194, width:30},
-      {top:-210, mid:-194, base:-182, width:44}
+      {top:-230, mid:-220, base:-206, width:14},
+      {top:-220, mid:-206, base:-192, width:26},
+      {top:-208, mid:-192, base:-178, width:36}
     ];
     for(const side of [-1,1]){
       ctx.save();
       ctx.scale(side,1);
-      ctx.fillStyle=metalGradient(-32,-220,-4,-176);
+      ctx.fillStyle=metalGradient(-28,-216,-6,-174);
       ctx.strokeStyle=`rgba(255,242,226,${flash?0.92:0.78})`;
-      ctx.lineWidth=1.5;
+      ctx.lineWidth=1.4;
       for(const segment of crownSegments){
         ctx.beginPath();
         ctx.moveTo(0, segment.mid);
-        ctx.lineTo(segment.width*0.4, segment.base);
+        ctx.lineTo(segment.width*0.45, segment.base);
         ctx.lineTo(segment.width, segment.mid);
-        ctx.lineTo(segment.width*0.6, segment.top);
+        ctx.lineTo(segment.width*0.58, segment.top);
         ctx.lineTo(0, segment.top+4);
         ctx.closePath();
         ctx.fill();
@@ -5915,64 +5919,64 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
       ctx.restore();
     }
 
-    // angular upper beak
-    ctx.fillStyle=metalGradient(-58,-48,58,-10);
+    // angular upper beak refined for Ra styling
+    ctx.fillStyle=metalGradient(-48,-50,48,-8);
     ctx.beginPath();
-    ctx.moveTo(-56,-6);
-    ctx.quadraticCurveTo(-78,-52,-32,-130);
-    ctx.lineTo(0,-170);
-    ctx.lineTo(32,-130);
-    ctx.quadraticCurveTo(78,-52,56,-6);
-    ctx.quadraticCurveTo(12,16,0,20);
-    ctx.quadraticCurveTo(-12,16,-56,-6);
+    ctx.moveTo(-44,0);
+    ctx.quadraticCurveTo(-70,-52,-28,-132);
+    ctx.lineTo(0,-166);
+    ctx.lineTo(28,-132);
+    ctx.quadraticCurveTo(70,-52,44,0);
+    ctx.quadraticCurveTo(12,14,0,18);
+    ctx.quadraticCurveTo(-12,14,-44,0);
     ctx.closePath();
     ctx.fill();
     ctx.strokeStyle=`rgba(255,236,216,${flash?0.92:0.76})`;
-    ctx.lineWidth=2.2;
+    ctx.lineWidth=2;
     ctx.stroke();
 
     // tapered lower jaw armor
-    ctx.fillStyle=metalGradient(-42,0,42,56);
+    ctx.fillStyle=metalGradient(-32,2,32,46);
     ctx.beginPath();
-    ctx.moveTo(-38,4);
-    ctx.lineTo(-14,30);
-    ctx.quadraticCurveTo(0,40,14,30);
-    ctx.lineTo(38,4);
-    ctx.lineTo(16,-12);
-    ctx.lineTo(-16,-12);
+    ctx.moveTo(-30,6);
+    ctx.lineTo(-12,26);
+    ctx.quadraticCurveTo(0,34,12,26);
+    ctx.lineTo(30,6);
+    ctx.lineTo(14,-12);
+    ctx.lineTo(-14,-12);
     ctx.closePath();
     ctx.fill();
     ctx.strokeStyle=`rgba(255,232,210,${flash?0.9:0.74})`;
-    ctx.lineWidth=1.9;
+    ctx.lineWidth=1.7;
     ctx.stroke();
 
     ctx.fillStyle='rgba(32,10,6,0.9)';
     ctx.beginPath();
-    ctx.moveTo(-30,-6);
-    ctx.quadraticCurveTo(0,-30,30,-6);
-    ctx.quadraticCurveTo(8,12,0,18);
-    ctx.quadraticCurveTo(-8,12,-30,-6);
+    ctx.moveTo(-24,-4);
+    ctx.quadraticCurveTo(0,-26,24,-4);
+    ctx.quadraticCurveTo(6,10,0,16);
+    ctx.quadraticCurveTo(-6,10,-24,-4);
     ctx.closePath();
     ctx.fill();
 
     ctx.strokeStyle=`rgba(255,228,200,${flash?0.86:0.68})`;
-    ctx.lineWidth=1.6;
+    ctx.lineWidth=1.5;
     ctx.beginPath();
-    ctx.moveTo(-24,2);
-    ctx.lineTo(-10,22);
-    ctx.moveTo(24,2);
-    ctx.lineTo(10,22);
+    ctx.moveTo(-20,2);
+    ctx.lineTo(-8,20);
+    ctx.moveTo(20,2);
+    ctx.lineTo(8,20);
     ctx.stroke();
 
-    // new beak teeth
+    // beak teeth
     ctx.fillStyle=flash?'#fffef4':'#fdf2d6';
     for(const side of [-1,1]){
       for(let i=0;i<3;i++){
-        const offset=-14 + i*10;
+        const offset=-12 + i*9;
         ctx.beginPath();
-        ctx.moveTo(offset*side,-4);
-        ctx.lineTo((offset+3)*side,10);
-        ctx.lineTo((offset+1)*side,4);
+        ctx.moveTo(offset*side,-2);
+        ctx.lineTo((offset+3)*side,8);
+        ctx.lineTo((offset+1)*side,2);
         ctx.closePath();
         ctx.fill();
       }
@@ -5983,9 +5987,9 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
       ctx.save();
       ctx.scale(side,1);
       const cheekPanels=[
-        {points:[[46,-24],[106,-74],[84,-12],[52,-2]]},
-        {points:[[44,-2],[124,6],[86,40],[48,18]]},
-        {points:[[40,22],[112,72],[70,58],[46,34]]}
+        {points:[[40,-20],[94,-68],[74,-8],[46,-2]]},
+        {points:[[38,0],[112,14],[80,40],[46,20]]},
+        {points:[[34,22],[96,64],[60,52],[38,32]]}
       ];
       for(const panel of cheekPanels){
         ctx.beginPath();
@@ -5994,38 +5998,38 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
           ctx.lineTo(panel.points[i][0], panel.points[i][1]);
         }
         ctx.closePath();
-        ctx.fillStyle=metalGradient(-60,-10,80,panel.points[1][1]+20);
+        ctx.fillStyle=metalGradient(-54,-8,72,panel.points[1][1]+18);
         ctx.fill();
         ctx.strokeStyle=`rgba(255,236,212,${flash?0.88:0.7})`;
-        ctx.lineWidth=1.4;
+        ctx.lineWidth=1.3;
         ctx.stroke();
       }
-      const spikeGrad=metalGradient(-66,-58,90,12);
+      const spikeGrad=metalGradient(-60,-52,84,10);
       ctx.fillStyle=spikeGrad;
       ctx.beginPath();
-      ctx.moveTo(54,-44);
-      ctx.lineTo(102,-118);
-      ctx.lineTo(78,-38);
+      ctx.moveTo(48,-40);
+      ctx.lineTo(96,-112);
+      ctx.lineTo(72,-34);
       ctx.closePath();
       ctx.fill();
       ctx.strokeStyle=`rgba(255,240,220,${flash?0.88:0.72})`;
-      ctx.lineWidth=1.5;
+      ctx.lineWidth=1.4;
       ctx.stroke();
       ctx.restore();
     }
 
     // radiant forehead gem
     ctx.save();
-    ctx.translate(0,-134);
-    const gemGrad=ctx.createRadialGradient(0,0,0,0,0,20);
+    ctx.translate(0,-128);
+    const gemGrad=ctx.createRadialGradient(0,0,0,0,0,18);
     gemGrad.addColorStop(0, flash?'#eaffff':'#9effff');
     gemGrad.addColorStop(0.5, flash?'rgba(120,252,255,0.95)':'rgba(60,228,250,0.92)');
     gemGrad.addColorStop(1,'rgba(0,140,180,0)');
     ctx.beginPath();
-    ctx.ellipse(0,0,12,18,0,0,Math.PI*2);
+    ctx.ellipse(0,0,11,16,0,0,Math.PI*2);
     ctx.fillStyle=gemGrad;
     ctx.shadowColor=flash?'rgba(120,252,255,0.86)':'rgba(60,220,240,0.72)';
-    ctx.shadowBlur=24;
+    ctx.shadowBlur=22;
     ctx.fill();
     ctx.restore();
 
@@ -6035,29 +6039,31 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
     const eyeFill=flash?'rgba(210,255,255,0.95)':'rgba(80,220,255,0.85)';
     ctx.fillStyle=eyeFill;
     ctx.shadowColor=flash?'rgba(200,255,255,0.8)':'rgba(60,210,250,0.65)';
-    ctx.shadowBlur=16;
+    ctx.shadowBlur=14;
     ctx.beginPath();
-    ctx.moveTo(-34,-34);
-    ctx.quadraticCurveTo(-18,-46,-8,-34);
-    ctx.quadraticCurveTo(-14,-28,-34,-30);
+    ctx.moveTo(-28,-30);
+    ctx.quadraticCurveTo(-16,-44,-6,-32);
+    ctx.quadraticCurveTo(-12,-26,-28,-28);
     ctx.closePath();
     ctx.fill();
     ctx.beginPath();
-    ctx.moveTo(34,-34);
-    ctx.quadraticCurveTo(18,-46,8,-34);
-    ctx.quadraticCurveTo(14,-28,34,-30);
+    ctx.moveTo(28,-30);
+    ctx.quadraticCurveTo(16,-44,6,-32);
+    ctx.quadraticCurveTo(12,-26,28,-28);
     ctx.closePath();
     ctx.fill();
     ctx.restore();
 
     ctx.strokeStyle=darkMetal(0.85);
-    ctx.lineWidth=2;
+    ctx.lineWidth=1.8;
     ctx.beginPath();
-    ctx.moveTo(-26,-58);
-    ctx.quadraticCurveTo(0,-76,26,-58);
-    ctx.moveTo(-20,-28);
-    ctx.quadraticCurveTo(0,-40,20,-28);
+    ctx.moveTo(-22,-54);
+    ctx.quadraticCurveTo(0,-72,22,-54);
+    ctx.moveTo(-18,-26);
+    ctx.quadraticCurveTo(0,-38,18,-26);
     ctx.stroke();
+
+    ctx.restore();
 
     ctx.restore();
     ctx.restore();


### PR DESCRIPTION
## Summary
- shrink the dragon boss activation bounds to half-size so its rendered form occupies a smaller footprint
- rebuild the head rendering with additional scaling and new geometry inspired by the Winged Dragon of Ra, including slimmer beak and cheek armor detailing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ceba793a388328aece97d32e9c7143