### PR TITLE
Refine dragon animation and head design

### DIFF
--- a/index.html
+++ b/index.html
@@ -5041,7 +5041,7 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
       }
       dragonBoss.hoverPhase += dt*0.002;
       dragonBoss.y = dragonBoss.baseY + Math.sin(dragonBoss.hoverPhase)*10;
-      dragonBoss.wingPhase += dt*0.01;
+      dragonBoss.wingPhase += dt*0.0065;
     }else if(dragonPhase==='dying'){
       const anim=dragonDeathAnim;
       if(anim){
@@ -5092,10 +5092,14 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
     ctx.save();
     ctx.translate(boss.x*scaleX, boss.y*scaleY);
     ctx.scale(scaleAvg*bodyScale, scaleAvg*bodyScale);
-    const flap=Math.sin(now/220 + boss.wingPhase)*0.55;
+    const wingCycle=boss.wingPhase;
+    const sine=Math.sin(wingCycle);
+    const downstroke=Math.pow(Math.max(0, sine), 1.6);
+    const upstroke=Math.pow(Math.max(0, -sine), 1.2);
+    const flap=(downstroke*0.65 - upstroke*0.42) + Math.sin(now*0.0032)*0.08;
     const flash = boss.hitFlashUntil && now<boss.hitFlashUntil;
-    const wingLift = 22*flap;
-    const wingSpread = 1.5 + flap*0.35;
+    const wingLift = 26*flap;
+    const wingSpread = 1.38 + flap*0.42;
     const shimmerHighlight = flash ? 1 : 0;
 
     const metalGradient=(x0,y0,x1,y1)=>{
@@ -5894,128 +5898,163 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
       ctx.stroke();
     }
 
-    const crownSegments=[
-      {top:-230, mid:-220, base:-206, width:14},
-      {top:-220, mid:-206, base:-192, width:26},
-      {top:-208, mid:-192, base:-178, width:36}
+    const crestLayers=[
+      {top:-252, mid:-228, base:-202, width:28, flare:16},
+      {top:-236, mid:-212, base:-188, width:34, flare:18},
+      {top:-220, mid:-198, base:-176, width:38, flare:20},
+      {top:-204, mid:-184, base:-164, width:42, flare:24}
     ];
+    ctx.save();
+    ctx.translate(0,-4);
+    ctx.fillStyle=metalGradient(-24,-232,24,-168);
+    ctx.strokeStyle=`rgba(255,242,226,${flash?0.92:0.78})`;
+    ctx.lineWidth=1.4;
+    for(const layer of crestLayers){
+      ctx.beginPath();
+      ctx.moveTo(0, layer.top);
+      ctx.quadraticCurveTo(-layer.width*0.42, layer.mid-layer.flare*0.4, -layer.width*0.6, layer.base);
+      ctx.lineTo(0, layer.mid+6);
+      ctx.lineTo(layer.width*0.6, layer.base);
+      ctx.quadraticCurveTo(layer.width*0.42, layer.mid-layer.flare*0.4, 0, layer.top);
+      ctx.closePath();
+      ctx.fill();
+      ctx.stroke();
+    }
+    ctx.restore();
+
     for(const side of [-1,1]){
       ctx.save();
       ctx.scale(side,1);
-      ctx.fillStyle=metalGradient(-28,-216,-6,-174);
-      ctx.strokeStyle=`rgba(255,242,226,${flash?0.92:0.78})`;
+      ctx.fillStyle=metalGradient(-86,-214,120,-34);
+      ctx.beginPath();
+      ctx.moveTo(0,-188);
+      ctx.quadraticCurveTo(86,-234,138,-144);
+      ctx.quadraticCurveTo(112,-118,78,-48);
+      ctx.lineTo(46,-30);
+      ctx.lineTo(34,-64);
+      ctx.quadraticCurveTo(64,-122,0,-188);
+      ctx.closePath();
+      ctx.fill();
+      ctx.strokeStyle=`rgba(255,236,214,${flash?0.9:0.74})`;
       ctx.lineWidth=1.4;
-      for(const segment of crownSegments){
-        ctx.beginPath();
-        ctx.moveTo(0, segment.mid);
-        ctx.lineTo(segment.width*0.45, segment.base);
-        ctx.lineTo(segment.width, segment.mid);
-        ctx.lineTo(segment.width*0.58, segment.top);
-        ctx.lineTo(0, segment.top+4);
-        ctx.closePath();
-        ctx.fill();
-        ctx.stroke();
-      }
-      ctx.restore();
-    }
+      ctx.stroke();
 
-    // angular upper beak refined for Ra styling
-    ctx.fillStyle=metalGradient(-48,-50,48,-8);
-    ctx.beginPath();
-    ctx.moveTo(-44,0);
-    ctx.quadraticCurveTo(-70,-52,-28,-132);
-    ctx.lineTo(0,-166);
-    ctx.lineTo(28,-132);
-    ctx.quadraticCurveTo(70,-52,44,0);
-    ctx.quadraticCurveTo(12,14,0,18);
-    ctx.quadraticCurveTo(-12,14,-44,0);
-    ctx.closePath();
-    ctx.fill();
-    ctx.strokeStyle=`rgba(255,236,216,${flash?0.92:0.76})`;
-    ctx.lineWidth=2;
-    ctx.stroke();
-
-    // tapered lower jaw armor
-    ctx.fillStyle=metalGradient(-32,2,32,46);
-    ctx.beginPath();
-    ctx.moveTo(-30,6);
-    ctx.lineTo(-12,26);
-    ctx.quadraticCurveTo(0,34,12,26);
-    ctx.lineTo(30,6);
-    ctx.lineTo(14,-12);
-    ctx.lineTo(-14,-12);
-    ctx.closePath();
-    ctx.fill();
-    ctx.strokeStyle=`rgba(255,232,210,${flash?0.9:0.74})`;
-    ctx.lineWidth=1.7;
-    ctx.stroke();
-
-    ctx.fillStyle='rgba(32,10,6,0.9)';
-    ctx.beginPath();
-    ctx.moveTo(-24,-4);
-    ctx.quadraticCurveTo(0,-26,24,-4);
-    ctx.quadraticCurveTo(6,10,0,16);
-    ctx.quadraticCurveTo(-6,10,-24,-4);
-    ctx.closePath();
-    ctx.fill();
-
-    ctx.strokeStyle=`rgba(255,228,200,${flash?0.86:0.68})`;
-    ctx.lineWidth=1.5;
-    ctx.beginPath();
-    ctx.moveTo(-20,2);
-    ctx.lineTo(-8,20);
-    ctx.moveTo(20,2);
-    ctx.lineTo(8,20);
-    ctx.stroke();
-
-    // beak teeth
-    ctx.fillStyle=flash?'#fffef4':'#fdf2d6';
-    for(const side of [-1,1]){
-      for(let i=0;i<3;i++){
-        const offset=-12 + i*9;
-        ctx.beginPath();
-        ctx.moveTo(offset*side,-2);
-        ctx.lineTo((offset+3)*side,8);
-        ctx.lineTo((offset+1)*side,2);
-        ctx.closePath();
-        ctx.fill();
-      }
-    }
-
-    // cheek spikes and solar flares
-    for(const side of [-1,1]){
-      ctx.save();
-      ctx.scale(side,1);
-      const cheekPanels=[
-        {points:[[40,-20],[94,-68],[74,-8],[46,-2]]},
-        {points:[[38,0],[112,14],[80,40],[46,20]]},
-        {points:[[34,22],[96,64],[60,52],[38,32]]}
+      const cheekFans=[
+        {points:[[34,-24],[98,-90],[82,-18],[46,-6]]},
+        {points:[[30,-2],[124,10],[92,56],[44,26]]},
+        {points:[[26,24],[102,72],[64,60],[36,40]]}
       ];
-      for(const panel of cheekPanels){
+      for(const panel of cheekFans){
         ctx.beginPath();
         ctx.moveTo(panel.points[0][0], panel.points[0][1]);
         for(let i=1;i<panel.points.length;i++){
           ctx.lineTo(panel.points[i][0], panel.points[i][1]);
         }
         ctx.closePath();
-        ctx.fillStyle=metalGradient(-54,-8,72,panel.points[1][1]+18);
+        ctx.fillStyle=metalGradient(-60,-12,84,panel.points[1][1]+18);
         ctx.fill();
-        ctx.strokeStyle=`rgba(255,236,212,${flash?0.88:0.7})`;
+        ctx.strokeStyle=`rgba(255,238,214,${flash?0.9:0.72})`;
         ctx.lineWidth=1.3;
         ctx.stroke();
       }
-      const spikeGrad=metalGradient(-60,-52,84,10);
-      ctx.fillStyle=spikeGrad;
+
+      ctx.fillStyle=metalGradient(-68,-86,92,6);
       ctx.beginPath();
-      ctx.moveTo(48,-40);
-      ctx.lineTo(96,-112);
-      ctx.lineTo(72,-34);
+      ctx.moveTo(46,-46);
+      ctx.lineTo(110,-126);
+      ctx.lineTo(76,-20);
       ctx.closePath();
       ctx.fill();
-      ctx.strokeStyle=`rgba(255,240,220,${flash?0.88:0.72})`;
+      ctx.strokeStyle=`rgba(255,240,220,${flash?0.9:0.74})`;
       ctx.lineWidth=1.4;
       ctx.stroke();
       ctx.restore();
+    }
+
+    // angular upper beak with layered crown
+    ctx.fillStyle=metalGradient(-52,-64,52,-4);
+    ctx.beginPath();
+    ctx.moveTo(-48,-2);
+    ctx.quadraticCurveTo(-86,-70,-32,-170);
+    ctx.lineTo(0,-198);
+    ctx.lineTo(32,-170);
+    ctx.quadraticCurveTo(86,-70,48,-2);
+    ctx.quadraticCurveTo(14,16,0,20);
+    ctx.quadraticCurveTo(-14,16,-48,-2);
+    ctx.closePath();
+    ctx.fill();
+    ctx.strokeStyle=`rgba(255,238,218,${flash?0.92:0.78})`;
+    ctx.lineWidth=2.1;
+    ctx.stroke();
+
+    // sculpted nasal ridge
+    ctx.strokeStyle=`rgba(255,230,206,${flash?0.9:0.74})`;
+    ctx.lineWidth=1.4;
+    ctx.beginPath();
+    ctx.moveTo(0,-182);
+    ctx.quadraticCurveTo(0,-112,0,-12);
+    ctx.stroke();
+
+    // layered lower jaw armor
+    ctx.fillStyle=metalGradient(-36,-6,36,60);
+    ctx.beginPath();
+    ctx.moveTo(-34,2);
+    ctx.lineTo(-18,40);
+    ctx.quadraticCurveTo(0,54,18,40);
+    ctx.lineTo(34,2);
+    ctx.lineTo(14,-16);
+    ctx.lineTo(-14,-16);
+    ctx.closePath();
+    ctx.fill();
+    ctx.strokeStyle=`rgba(255,234,210,${flash?0.9:0.74})`;
+    ctx.lineWidth=1.8;
+    ctx.stroke();
+
+    ctx.fillStyle=metalGradient(-26,12,26,72);
+    ctx.beginPath();
+    ctx.moveTo(-22,14);
+    ctx.lineTo(-8,48);
+    ctx.quadraticCurveTo(0,58,8,48);
+    ctx.lineTo(22,14);
+    ctx.lineTo(10,0);
+    ctx.lineTo(-10,0);
+    ctx.closePath();
+    ctx.fill();
+    ctx.strokeStyle=`rgba(255,240,220,${flash?0.92:0.78})`;
+    ctx.lineWidth=1.5;
+    ctx.stroke();
+
+    // interior maw shading
+    ctx.fillStyle='rgba(32,8,6,0.9)';
+    ctx.beginPath();
+    ctx.moveTo(-28,-4);
+    ctx.quadraticCurveTo(0,-30,28,-4);
+    ctx.quadraticCurveTo(10,14,0,20);
+    ctx.quadraticCurveTo(-10,14,-28,-4);
+    ctx.closePath();
+    ctx.fill();
+
+    ctx.strokeStyle=`rgba(255,226,200,${flash?0.86:0.68})`;
+    ctx.lineWidth=1.5;
+    ctx.beginPath();
+    ctx.moveTo(-22,2);
+    ctx.lineTo(-10,24);
+    ctx.moveTo(22,2);
+    ctx.lineTo(10,24);
+    ctx.stroke();
+
+    // serrated beak teeth
+    ctx.fillStyle=flash?'#fffdf0':'#fdf1d2';
+    for(const side of [-1,1]){
+      for(let i=0;i<4;i++){
+        const offset=-14 + i*8;
+        ctx.beginPath();
+        ctx.moveTo(offset*side,-4);
+        ctx.lineTo((offset+3)*side,8);
+        ctx.lineTo((offset+1)*side,2);
+        ctx.closePath();
+        ctx.fill();
+      }
     }
 
     // radiant forehead gem
@@ -6036,20 +6075,20 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
     // luminous eyes
     ctx.save();
     ctx.globalCompositeOperation='lighter';
-    const eyeFill=flash?'rgba(210,255,255,0.95)':'rgba(80,220,255,0.85)';
+    const eyeFill=flash?'rgba(255,188,160,0.96)':'rgba(255,72,44,0.9)';
     ctx.fillStyle=eyeFill;
-    ctx.shadowColor=flash?'rgba(200,255,255,0.8)':'rgba(60,210,250,0.65)';
-    ctx.shadowBlur=14;
+    ctx.shadowColor=flash?'rgba(255,140,90,0.88)':'rgba(255,70,30,0.72)';
+    ctx.shadowBlur=16;
     ctx.beginPath();
-    ctx.moveTo(-28,-30);
-    ctx.quadraticCurveTo(-16,-44,-6,-32);
-    ctx.quadraticCurveTo(-12,-26,-28,-28);
+    ctx.moveTo(-30,-30);
+    ctx.quadraticCurveTo(-18,-50,-4,-40);
+    ctx.quadraticCurveTo(-14,-26,-32,-26);
     ctx.closePath();
     ctx.fill();
     ctx.beginPath();
-    ctx.moveTo(28,-30);
-    ctx.quadraticCurveTo(16,-44,6,-32);
-    ctx.quadraticCurveTo(12,-26,28,-28);
+    ctx.moveTo(30,-30);
+    ctx.quadraticCurveTo(18,-50,4,-40);
+    ctx.quadraticCurveTo(14,-26,32,-26);
     ctx.closePath();
     ctx.fill();
     ctx.restore();
@@ -6057,10 +6096,10 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
     ctx.strokeStyle=darkMetal(0.85);
     ctx.lineWidth=1.8;
     ctx.beginPath();
-    ctx.moveTo(-22,-54);
-    ctx.quadraticCurveTo(0,-72,22,-54);
-    ctx.moveTo(-18,-26);
-    ctx.quadraticCurveTo(0,-38,18,-26);
+    ctx.moveTo(-24,-56);
+    ctx.quadraticCurveTo(0,-78,24,-56);
+    ctx.moveTo(-20,-24);
+    ctx.quadraticCurveTo(0,-36,20,-24);
     ctx.stroke();
 
     ctx.restore();


### PR DESCRIPTION
## Summary
- slow the dragon boss wingbeat timing and adjust the wing pose animation curve for a heavier, more natural flap
- rebuild the dragon head with layered crest, horns, beak armor, and glowing red eyes inspired by the reference images

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cec136733483288e5c6978ae679f42