### PR TITLE
Add dragon lock box highlight when targeted

### DIFF
--- a/index.html
+++ b/index.html
@@ -1492,7 +1492,16 @@ select optgroup { color: #0b1022; }
       return;
     }
     const bounds=getSpaceBossBounds();
-    if(bounds){ pushLockBox(bounds.x, bounds.y, bounds.w, bounds.h, 'target'); }
+    if(bounds){
+      pushLockBox(bounds.x, bounds.y, bounds.w, bounds.h, 'target');
+      return;
+    }
+    if(isDragonActive()){
+      const dragonBounds=getDragonBounds();
+      if(dragonBounds){
+        pushLockBox(dragonBounds.x, dragonBounds.y, dragonBounds.w, dragonBounds.h, 'target');
+      }
+    }
   }
     let scoreUploaded=false;
     let uploading=false;


### PR DESCRIPTION
## Summary
- stop further processing after highlighting the reaper or space boss
- add dragon boss handling to highlightSpaceBossTarget to push a lock box when active

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cec8a274208328836e436498a3969c