### PR TITLE
Refine dragon boss visuals and collisions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1295,6 +1295,7 @@ select optgroup { color: #0b1022; }
   const SPACE_BOSS_GUN_FIRE_DURATION = 3000;
   const SPACE_BOSS_LASER_SWEEP_DURATION = 2000;
   const DRAGON_MAX_HP = 50;
+  const DRAGON_BASE_MODEL_WIDTH = 260;
   let spaceBossPhase='inactive';
   let spaceBoss=null;
   let spaceBossPlaceholder=null;
@@ -1372,14 +1373,81 @@ select optgroup { color: #0b1022; }
     };
   }
 
+  function computeDragonHitZones(bossOverride=null){
+    const boss = bossOverride || dragonBoss;
+    if(!boss) return [];
+    const scale = (boss.w||DRAGON_BASE_MODEL_WIDTH)/DRAGON_BASE_MODEL_WIDTH;
+    const cx = boss.x;
+    const cy = boss.y;
+    const wingPhase = boss.wingPhase||0;
+    const sine=Math.sin(wingPhase);
+    const downstroke=Math.pow(Math.max(0, sine), 1.6);
+    const upstroke=Math.pow(Math.max(0, -sine), 1.2);
+    const flap=(downstroke*0.65 - upstroke*0.42);
+    const wingLift = 26*flap;
+    const wingSpread = 1.38 + flap*0.42;
+    const zones=[];
+    const addZone=(ox, oy, radius)=>{
+      zones.push({
+        cx: cx + ox*scale,
+        cy: cy + oy*scale,
+        r: Math.max(6, radius*scale)
+      });
+    };
+
+    addZone(0,-48,62);
+    addZone(0,24,70);
+    addZone(0,110,58);
+    addZone(0,190,48);
+    addZone(0,268,42);
+    addZone(0,-132,28);
+
+    addZone(96,-12,42);
+    addZone(-96,-12,42);
+    addZone(102,108,38);
+    addZone(-102,108,38);
+
+    const tailSegments=[
+      {y:146,r:44},
+      {y:214,r:38},
+      {y:286,r:32},
+      {y:344,r:28}
+    ];
+    for(const seg of tailSegments){ addZone(0,seg.y,seg.r); }
+
+    const wingClusters=[
+      {x:-150, y:-72-wingLift*0.15, r:76},
+      {x:-212, y:18-wingLift*0.05, r:70},
+      {x:-252, y:126+wingLift*0.18, r:64},
+      {x:-220, y:202+wingLift*0.32, r:58}
+    ];
+    for(const cluster of wingClusters){
+      addZone(cluster.x*wingSpread, cluster.y, cluster.r);
+      addZone(-cluster.x*wingSpread, cluster.y, cluster.r);
+    }
+
+    return zones;
+  }
+
   function getDragonBounds(){
     if(!dragonBoss) return null;
-    return {
-      x: dragonBoss.x - dragonBoss.w/2,
-      y: dragonBoss.y - dragonBoss.h/2,
-      w: dragonBoss.w,
-      h: dragonBoss.h
-    };
+    const zones=computeDragonHitZones();
+    if(!zones.length){
+      return {
+        x: dragonBoss.x - dragonBoss.w/2,
+        y: dragonBoss.y - dragonBoss.h/2,
+        w: dragonBoss.w,
+        h: dragonBoss.h
+      };
+    }
+    let minX=Infinity, minY=Infinity, maxX=-Infinity, maxY=-Infinity;
+    for(const zone of zones){
+      minX=Math.min(minX, zone.cx - zone.r);
+      minY=Math.min(minY, zone.cy - zone.r);
+      maxX=Math.max(maxX, zone.cx + zone.r);
+      maxY=Math.max(maxY, zone.cy + zone.r);
+    }
+    return {x:minX, y:minY, w:maxX-minX, h:maxY-minY};
   }
 
   function circleIntersectsSpaceBoss(cx, cy, radius){
@@ -1393,13 +1461,117 @@ select optgroup { color: #0b1022; }
   }
 
   function circleIntersectsDragon(cx, cy, radius){
-    const bounds=getDragonBounds();
-    if(!bounds) return false;
-    const nearestX = Math.max(bounds.x, Math.min(cx, bounds.x + bounds.w));
-    const nearestY = Math.max(bounds.y, Math.min(cy, bounds.y + bounds.h));
-    const dx = cx - nearestX;
-    const dy = cy - nearestY;
-    return dx*dx + dy*dy <= radius*radius;
+    const zones=computeDragonHitZones();
+    if(!zones.length) return false;
+    for(const zone of zones){
+      const dx=cx-zone.cx;
+      const dy=cy-zone.cy;
+      const rr=radius + zone.r;
+      if(dx*dx + dy*dy <= rr*rr) return true;
+    }
+    return false;
+  }
+
+  function resolveDragonBallCollision(ball, radius, inRampage){
+    const zones=computeDragonHitZones();
+    if(!zones.length) return null;
+    let best=null;
+    for(const zone of zones){
+      const dx=ball.x - zone.cx;
+      const dy=ball.y - zone.cy;
+      const dist=Math.hypot(dx,dy);
+      const overlap=(zone.r + radius) - dist;
+      if(overlap>0 && (!best || overlap>best.overlap)){
+        best={zone, dx, dy, dist:dist||0.0001, overlap};
+      }
+    }
+    if(!best) return null;
+    const nx=best.dx/(best.dist||0.0001);
+    const ny=best.dy/(best.dist||0.0001);
+    const impactX=best.zone.cx + nx*best.zone.r;
+    const impactY=best.zone.cy + ny*best.zone.r;
+    ball.x = impactX + nx*(radius+0.5);
+    ball.y = impactY + ny*(radius+0.5);
+    const dot = ball.vx*nx + ball.vy*ny;
+    ball.vx -= 2*dot*nx;
+    ball.vy -= 2*dot*ny;
+    if(inRampage || ball.piercing){
+      ball.piercing=true;
+    }
+    if(Math.abs(ball.vx)<0.2){ ball.vx += nx*4; }
+    if(Math.abs(ball.vy)<0.2){ ball.vy += ny*4; }
+    const bounceAxis = Math.abs(nx) > Math.abs(ny) ? 'x' : 'y';
+    return {impactX, impactY, bounceAxis};
+  }
+
+  function triggerBallBuffEffectsOnBossHit(ball, impactX, impactY, now){
+    if(buffs.PLASMA.active){
+      const cfg=GAME_CONFIG.powers.PLASMA.plasma;
+      const ang=Math.random()*Math.PI*2;
+      plasmas.push({
+        x:impactX,
+        y:impactY,
+        vx:Math.cos(ang)*cfg.drift,
+        vy:Math.sin(ang)*cfg.drift,
+        until:now+cfg.lifeMs,
+        radius:cfg.radius,
+        phase:Math.random()*Math.PI*2
+      });
+      playSFX('plasma');
+    }
+
+    if(buffs.FREEZE.active && (ball.freeze.state==='idle' || !ball.freeze.state)){
+      const f=GAME_CONFIG.powers.FREEZE.freeze;
+      ball.freeze.state='delay';
+      ball.freeze.t0=now;
+      ball.freeze.delay=f.delayMs;
+      ball.freeze.stop=f.stopMs;
+      ball.freeze.oldVX=ball.vx;
+      ball.freeze.oldVY=ball.vy;
+    }
+
+    if(buffs.HOLY.active){
+      playSFX('holy');
+      holyFlashes.push({x:impactX, y:impactY, until:now+350});
+      const L=layout();
+      const rowIdx=Math.round((impactY - L.top) / (brickH + L.pad));
+      const colIdx=Math.round((impactX - L.pad) / (brickW + L.pad));
+      const rowY=L.top + rowIdx*(brickH + L.pad) + brickH/2;
+      const colX=L.pad + colIdx*(brickW + L.pad) + brickW/2;
+      for(let i=bricks.length-1;i>=0;i--){
+        const t=bricks[i];
+        const sameRow=Math.abs((t.y+t.h/2) - rowY)<1;
+        const sameCol=Math.abs((t.x+t.w/2) - colX)<1;
+        if(sameRow || sameCol){ destroyBrick(i,'none'); }
+      }
+      if(isSpecialBossActive()){
+        const bounds=getActiveBossBounds();
+        let bossHit=false;
+        if(bounds && rowY>=bounds.y && rowY<=bounds.y+bounds.h){
+          const cx=bounds.x+bounds.w/2;
+          damageActiveBoss(1,'holy',{x:cx,y:rowY});
+          bossHit=true;
+        }
+        if(bounds && !bossHit && colX>=bounds.x && colX<=bounds.x+bounds.w){
+          const cy=bounds.y+bounds.h/2;
+          damageActiveBoss(1,'holy',{x:colX,y:cy});
+        }
+      }
+      screenShake=Math.max(screenShake,4);
+    }
+
+    if(buffs.HELL.active){
+      const holeSpin=(Math.random()>0.5?1:-1);
+      blackHoles.push({
+        x:impactX,
+        y:impactY,
+        r:40,
+        until:now+GAME_CONFIG.powers.HELL.hell.haloMs,
+        start:performance.now(),
+        spinDir:holeSpin
+      });
+      playSFX('blackhole');
+    }
   }
 
   function getReaperBounds(){
@@ -5862,213 +6034,178 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
     drawDragonHalo(ctx);
 
     ctx.save();
-    ctx.translate(0,-6);
-    ctx.scale(0.82,0.76);
+    ctx.translate(0,-12);
+    const headScaleX=0.41;
+    const headScaleY=0.38;
+    ctx.scale(headScaleX, headScaleY);
 
-    const headGrad=metalGradient(-58,-148,58,66);
-    ctx.fillStyle=headGrad;
+    const crownGrad=metalGradient(-70,-188,70,36);
+    ctx.fillStyle=crownGrad;
     ctx.beginPath();
-    ctx.moveTo(-56,22);
-    ctx.lineTo(-82,-18);
-    ctx.quadraticCurveTo(-102,-86,-52,-158);
-    ctx.quadraticCurveTo(-18,-206,-4,-214);
-    ctx.lineTo(0,-220);
-    ctx.lineTo(4,-214);
-    ctx.quadraticCurveTo(18,-206,52,-158);
-    ctx.quadraticCurveTo(102,-86,82,-18);
-    ctx.lineTo(56,22);
-    ctx.quadraticCurveTo(18,50,0,54);
-    ctx.quadraticCurveTo(-18,50,-56,22);
+    ctx.moveTo(0,-222);
+    ctx.lineTo(-44,-198);
+    ctx.quadraticCurveTo(-100,-132,-80,-56);
+    ctx.quadraticCurveTo(-40,8,-12,40);
+    ctx.lineTo(0,56);
+    ctx.lineTo(12,40);
+    ctx.quadraticCurveTo(40,8,80,-56);
+    ctx.quadraticCurveTo(100,-132,44,-198);
     ctx.closePath();
     ctx.fill();
-    ctx.strokeStyle=`rgba(255,240,220,${flash?0.94:0.8})`;
-    ctx.lineWidth=2.8;
+    ctx.strokeStyle=`rgba(255,238,214,${flash?0.96:0.82})`;
+    ctx.lineWidth=2.2;
     ctx.stroke();
 
-    // segmented forehead plates with central ridge
-    ctx.strokeStyle=`rgba(255,236,210,${flash?0.92:0.74})`;
-    ctx.lineWidth=2;
+    ctx.strokeStyle=darkMetal(0.92);
+    ctx.lineWidth=1.2;
     ctx.beginPath();
-    ctx.moveTo(0,-216);
-    ctx.lineTo(0,18);
+    ctx.moveTo(0,-210);
+    ctx.lineTo(0,-34);
+    ctx.moveTo(-28,-164);
+    ctx.lineTo(-10,-48);
+    ctx.moveTo(28,-164);
+    ctx.lineTo(10,-48);
     ctx.stroke();
-
-    const foreheadSteps=[
-      {y:-176, inset:18},
-      {y:-150, inset:24},
-      {y:-126, inset:30},
-      {y:-102, inset:34}
-    ];
-    ctx.lineWidth=1.5;
-    for(const step of foreheadSteps){
-      ctx.beginPath();
-      ctx.moveTo(-step.inset, step.y);
-      ctx.lineTo(step.inset, step.y);
-      ctx.stroke();
-    }
-
-    const crestLayers=[
-      {top:-252, mid:-228, base:-202, width:28, flare:16},
-      {top:-236, mid:-212, base:-188, width:34, flare:18},
-      {top:-220, mid:-198, base:-176, width:38, flare:20},
-      {top:-204, mid:-184, base:-164, width:42, flare:24}
-    ];
-    ctx.save();
-    ctx.translate(0,-4);
-    ctx.fillStyle=metalGradient(-24,-232,24,-168);
-    ctx.strokeStyle=`rgba(255,242,226,${flash?0.92:0.78})`;
-    ctx.lineWidth=1.4;
-    for(const layer of crestLayers){
-      ctx.beginPath();
-      ctx.moveTo(0, layer.top);
-      ctx.quadraticCurveTo(-layer.width*0.42, layer.mid-layer.flare*0.4, -layer.width*0.6, layer.base);
-      ctx.lineTo(0, layer.mid+6);
-      ctx.lineTo(layer.width*0.6, layer.base);
-      ctx.quadraticCurveTo(layer.width*0.42, layer.mid-layer.flare*0.4, 0, layer.top);
-      ctx.closePath();
-      ctx.fill();
-      ctx.stroke();
-    }
-    ctx.restore();
 
     for(const side of [-1,1]){
       ctx.save();
       ctx.scale(side,1);
-      ctx.fillStyle=metalGradient(-86,-214,120,-34);
+      ctx.fillStyle=metalGradient(-48,-160,96,-12);
       ctx.beginPath();
-      ctx.moveTo(0,-188);
-      ctx.quadraticCurveTo(86,-234,138,-144);
-      ctx.quadraticCurveTo(112,-118,78,-48);
-      ctx.lineTo(46,-30);
-      ctx.lineTo(34,-64);
-      ctx.quadraticCurveTo(64,-122,0,-188);
+      ctx.moveTo(16,-176);
+      ctx.lineTo(120,-128);
+      ctx.lineTo(94,-62);
+      ctx.quadraticCurveTo(46,-8,20,2);
+      ctx.lineTo(4,-22);
+      ctx.quadraticCurveTo(12,-86,16,-176);
       ctx.closePath();
       ctx.fill();
-      ctx.strokeStyle=`rgba(255,236,214,${flash?0.9:0.74})`;
-      ctx.lineWidth=1.4;
+      ctx.strokeStyle=`rgba(255,232,208,${flash?0.94:0.78})`;
+      ctx.lineWidth=1.8;
       ctx.stroke();
-
-      const cheekFans=[
-        {points:[[34,-24],[98,-90],[82,-18],[46,-6]]},
-        {points:[[30,-2],[124,10],[92,56],[44,26]]},
-        {points:[[26,24],[102,72],[64,60],[36,40]]}
-      ];
-      for(const panel of cheekFans){
-        ctx.beginPath();
-        ctx.moveTo(panel.points[0][0], panel.points[0][1]);
-        for(let i=1;i<panel.points.length;i++){
-          ctx.lineTo(panel.points[i][0], panel.points[i][1]);
-        }
-        ctx.closePath();
-        ctx.fillStyle=metalGradient(-60,-12,84,panel.points[1][1]+18);
-        ctx.fill();
-        ctx.strokeStyle=`rgba(255,238,214,${flash?0.9:0.72})`;
-        ctx.lineWidth=1.3;
-        ctx.stroke();
-      }
-
-      ctx.fillStyle=metalGradient(-68,-86,92,6);
+      ctx.strokeStyle=darkMetal(0.88);
+      ctx.lineWidth=1.1;
       ctx.beginPath();
-      ctx.moveTo(46,-46);
-      ctx.lineTo(110,-126);
-      ctx.lineTo(76,-20);
-      ctx.closePath();
-      ctx.fill();
-      ctx.strokeStyle=`rgba(255,240,220,${flash?0.9:0.74})`;
-      ctx.lineWidth=1.4;
+      ctx.moveTo(20,-156);
+      ctx.lineTo(78,-66);
+      ctx.lineTo(26,-14);
       ctx.stroke();
       ctx.restore();
     }
 
-    // angular upper beak with layered crown
-    ctx.fillStyle=metalGradient(-52,-64,52,-4);
+    for(const side of [-1,1]){
+      ctx.save();
+      ctx.scale(side,1);
+      ctx.fillStyle=metalGradient(-36,-36,72,66);
+      ctx.beginPath();
+      ctx.moveTo(-2,-12);
+      ctx.lineTo(46,12);
+      ctx.lineTo(62,64);
+      ctx.quadraticCurveTo(30,84,6,64);
+      ctx.lineTo(-6,20);
+      ctx.closePath();
+      ctx.fill();
+      ctx.strokeStyle=`rgba(255,244,226,${flash?0.96:0.84})`;
+      ctx.lineWidth=1.5;
+      ctx.stroke();
+      ctx.strokeStyle=darkMetal(0.9);
+      ctx.lineWidth=1.1;
+      ctx.beginPath();
+      ctx.moveTo(18,18);
+      ctx.lineTo(46,58);
+      ctx.stroke();
+      ctx.restore();
+    }
+
+    ctx.fillStyle=metalGradient(-44,-76,44,52);
     ctx.beginPath();
-    ctx.moveTo(-48,-2);
-    ctx.quadraticCurveTo(-86,-70,-32,-170);
-    ctx.lineTo(0,-198);
-    ctx.lineTo(32,-170);
-    ctx.quadraticCurveTo(86,-70,48,-2);
-    ctx.quadraticCurveTo(14,16,0,20);
-    ctx.quadraticCurveTo(-14,16,-48,-2);
+    ctx.moveTo(-32,-4);
+    ctx.lineTo(-68,-46);
+    ctx.quadraticCurveTo(-76,-104,-28,-174);
+    ctx.quadraticCurveTo(-6,-206,0,-216);
+    ctx.quadraticCurveTo(6,-206,28,-174);
+    ctx.quadraticCurveTo(76,-104,68,-46);
+    ctx.lineTo(32,-4);
+    ctx.quadraticCurveTo(0,20,-32,-4);
     ctx.closePath();
     ctx.fill();
-    ctx.strokeStyle=`rgba(255,238,218,${flash?0.92:0.78})`;
-    ctx.lineWidth=2.1;
+    ctx.strokeStyle=`rgba(255,240,220,${flash?0.94:0.8})`;
+    ctx.lineWidth=2;
     ctx.stroke();
 
-    // sculpted nasal ridge
-    ctx.strokeStyle=`rgba(255,230,206,${flash?0.9:0.74})`;
+    ctx.strokeStyle=`rgba(255,228,200,${flash?0.9:0.76})`;
     ctx.lineWidth=1.4;
     ctx.beginPath();
-    ctx.moveTo(0,-182);
-    ctx.quadraticCurveTo(0,-112,0,-12);
+    ctx.moveTo(-34,-54);
+    ctx.quadraticCurveTo(0,-92,34,-54);
     ctx.stroke();
 
-    // layered lower jaw armor
-    ctx.fillStyle=metalGradient(-36,-6,36,60);
     ctx.beginPath();
-    ctx.moveTo(-34,2);
-    ctx.lineTo(-18,40);
-    ctx.quadraticCurveTo(0,54,18,40);
-    ctx.lineTo(34,2);
-    ctx.lineTo(14,-16);
-    ctx.lineTo(-14,-16);
+    ctx.moveTo(0,-188);
+    ctx.quadraticCurveTo(0,-96,0,18);
+    ctx.stroke();
+
+    ctx.fillStyle=metalGradient(-32,6,32,78);
+    ctx.beginPath();
+    ctx.moveTo(-30,12);
+    ctx.lineTo(-14,64);
+    ctx.quadraticCurveTo(0,88,14,64);
+    ctx.lineTo(30,12);
+    ctx.lineTo(12,-18);
+    ctx.lineTo(-12,-18);
     ctx.closePath();
     ctx.fill();
-    ctx.strokeStyle=`rgba(255,234,210,${flash?0.9:0.74})`;
-    ctx.lineWidth=1.8;
+    ctx.strokeStyle=`rgba(255,236,214,${flash?0.92:0.78})`;
+    ctx.lineWidth=1.7;
     ctx.stroke();
 
-    ctx.fillStyle=metalGradient(-26,12,26,72);
+    ctx.fillStyle='rgba(32,8,6,0.92)';
     ctx.beginPath();
-    ctx.moveTo(-22,14);
-    ctx.lineTo(-8,48);
-    ctx.quadraticCurveTo(0,58,8,48);
-    ctx.lineTo(22,14);
-    ctx.lineTo(10,0);
-    ctx.lineTo(-10,0);
-    ctx.closePath();
-    ctx.fill();
-    ctx.strokeStyle=`rgba(255,240,220,${flash?0.92:0.78})`;
-    ctx.lineWidth=1.5;
-    ctx.stroke();
-
-    // interior maw shading
-    ctx.fillStyle='rgba(32,8,6,0.9)';
-    ctx.beginPath();
-    ctx.moveTo(-28,-4);
-    ctx.quadraticCurveTo(0,-30,28,-4);
-    ctx.quadraticCurveTo(10,14,0,20);
-    ctx.quadraticCurveTo(-10,14,-28,-4);
+    ctx.moveTo(-26,-6);
+    ctx.quadraticCurveTo(0,-34,26,-6);
+    ctx.quadraticCurveTo(10,16,0,24);
+    ctx.quadraticCurveTo(-10,16,-26,-6);
     ctx.closePath();
     ctx.fill();
 
-    ctx.strokeStyle=`rgba(255,226,200,${flash?0.86:0.68})`;
-    ctx.lineWidth=1.5;
+    ctx.fillStyle=metalGradient(-24,16,24,70);
     ctx.beginPath();
-    ctx.moveTo(-22,2);
-    ctx.lineTo(-10,24);
-    ctx.moveTo(22,2);
-    ctx.lineTo(10,24);
+    ctx.moveTo(-20,10);
+    ctx.lineTo(-4,56);
+    ctx.quadraticCurveTo(0,64,4,56);
+    ctx.lineTo(20,10);
+    ctx.lineTo(10,-8);
+    ctx.lineTo(-10,-8);
+    ctx.closePath();
+    ctx.fill();
+    ctx.strokeStyle=`rgba(255,240,224,${flash?0.94:0.82})`;
+    ctx.lineWidth=1.3;
     ctx.stroke();
 
-    // serrated beak teeth
     ctx.fillStyle=flash?'#fffdf0':'#fdf1d2';
     for(const side of [-1,1]){
-      for(let i=0;i<4;i++){
-        const offset=-14 + i*8;
+      for(let i=0;i<3;i++){
+        const offset=-12 + i*8;
         ctx.beginPath();
-        ctx.moveTo(offset*side,-4);
-        ctx.lineTo((offset+3)*side,8);
-        ctx.lineTo((offset+1)*side,2);
+        ctx.moveTo(offset*side,-6);
+        ctx.lineTo((offset+3)*side,6);
+        ctx.lineTo((offset+1.2)*side,0);
         ctx.closePath();
         ctx.fill();
       }
     }
 
-    // radiant forehead gem
+    ctx.strokeStyle=darkMetal(0.88);
+    ctx.lineWidth=1.1;
+    ctx.beginPath();
+    ctx.moveTo(-18,6);
+    ctx.lineTo(-6,48);
+    ctx.moveTo(18,6);
+    ctx.lineTo(6,48);
+    ctx.stroke();
+
     ctx.save();
-    ctx.translate(0,-128);
+    ctx.translate(0,-146);
     const gemGrad=ctx.createRadialGradient(0,0,0,0,0,18);
     gemGrad.addColorStop(0, flash?'#eaffff':'#9effff');
     gemGrad.addColorStop(0.5, flash?'rgba(120,252,255,0.95)':'rgba(60,228,250,0.92)');
@@ -6081,7 +6218,6 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
     ctx.fill();
     ctx.restore();
 
-    // luminous eyes
     ctx.save();
     ctx.globalCompositeOperation='lighter';
     const eyeFill=flash?'rgba(255,188,160,0.96)':'rgba(255,72,44,0.9)';
@@ -6089,27 +6225,18 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
     ctx.shadowColor=flash?'rgba(255,140,90,0.88)':'rgba(255,70,30,0.72)';
     ctx.shadowBlur=16;
     ctx.beginPath();
-    ctx.moveTo(-30,-30);
-    ctx.quadraticCurveTo(-18,-50,-4,-40);
-    ctx.quadraticCurveTo(-14,-26,-32,-26);
+    ctx.moveTo(-38,-28);
+    ctx.quadraticCurveTo(-26,-54,-12,-44);
+    ctx.quadraticCurveTo(-20,-24,-38,-20);
     ctx.closePath();
     ctx.fill();
     ctx.beginPath();
-    ctx.moveTo(30,-30);
-    ctx.quadraticCurveTo(18,-50,4,-40);
-    ctx.quadraticCurveTo(14,-26,32,-26);
+    ctx.moveTo(38,-28);
+    ctx.quadraticCurveTo(26,-54,12,-44);
+    ctx.quadraticCurveTo(20,-24,38,-20);
     ctx.closePath();
     ctx.fill();
     ctx.restore();
-
-    ctx.strokeStyle=darkMetal(0.85);
-    ctx.lineWidth=1.8;
-    ctx.beginPath();
-    ctx.moveTo(-24,-56);
-    ctx.quadraticCurveTo(0,-78,24,-56);
-    ctx.moveTo(-20,-24);
-    ctx.quadraticCurveTo(0,-36,20,-24);
-    ctx.stroke();
 
     ctx.restore();
 
@@ -8719,32 +8846,55 @@ function generateLevel(lv, L){
       }
 
       if(!collidedWithBrick && isSpecialBossActive()){
-        const bounds=getActiveBossBounds();
-        if(bounds){
-          const rx=bounds.x, ry=bounds.y, rw=bounds.w, rh=bounds.h;
-          if(b.x+r>rx && b.x-r<rx+rw && b.y+r>ry && b.y-r<ry+rh){
-            const oL=(b.x+r)-rx, oR=(rx+rw)-(b.x-r), oT=(b.y+r)-ry, oB=(ry+rh)-(b.y-r);
-            const m=Math.min(oL,oR,oT,oB);
-            let bounceAxis=null;
-            if(!inRampage && !b.piercing){
-              if(m===oL){ b.x=rx-r; b.vx=-Math.abs(b.vx)||-4; bounceAxis='x'; }
-              else if(m===oR){ b.x=rx+rw+r; b.vx=Math.abs(b.vx)||4; bounceAxis='x'; }
-              else if(m===oT){ b.y=ry-r; b.vy=-Math.abs(b.vy)||-4; bounceAxis='y'; }
-              else { b.y=ry+rh+r; b.vy=Math.abs(b.vy)||4; bounceAxis='y'; }
-            }else{
-              if(m===oL){ b.x=rx-r; b.vx=Math.abs(b.vx)||4; bounceAxis='x'; }
-              else if(m===oR){ b.x=rx+rw+r; b.vx=-Math.abs(b.vx)||-4; bounceAxis='x'; }
-              else if(m===oT){ b.y=ry-r; b.vy=Math.abs(b.vy)||4; bounceAxis='y'; }
-              else { b.y=ry+rh+r; b.vy=-Math.abs(b.vy)||-4; bounceAxis='y'; }
-              b.piercing=true;
-            }
-            if(bounceAxis){ noteBounce(b,b.x,b.y,bounceAxis,now); }
-            const impactX = Math.max(rx, Math.min(b.x, rx+rw));
-            const impactY = Math.max(ry, Math.min(b.y, ry+rh));
-            spawnParticles(impactX, impactY, '#b8d6ff', 20, 1.4, 2.4, 2.2);
+        if(isDragonActive() && dragonBoss){
+          const result=resolveDragonBallCollision(b, r, inRampage);
+          if(result){
             fireCollide();
-            damageActiveBoss(1,'ball',{x:impactX,y:impactY});
+            if(result.bounceAxis){ noteBounce(b,b.x,b.y,result.bounceAxis,now); }
+            spawnParticles(result.impactX, result.impactY, '#b8d6ff', 20, 1.4, 2.4, 2.2);
+            triggerBallBuffEffectsOnBossHit(b, result.impactX, result.impactY, now);
+            damageActiveBoss(1,'ball',{x:result.impactX,y:result.impactY});
+            if(buffs.TRACK.active){
+              const pr=paddleRect();
+              const tx = pr.x + (orientLeft? (pr.w + 60) : pr.w/2);
+              const ty = pr.y + pr.h/2;
+              const sp=Math.hypot(b.vx,b.vy);
+              const ang=Math.atan2(ty-b.y, tx-b.x);
+              b.vx=Math.cos(ang)*sp;
+              b.vy=Math.sin(ang)*sp;
+              pushLockBox(pr.x, pr.y, pr.w, pr.h, 'paddle');
+            }
+            beep(520+Math.random()*200,0.03,0.05);
             collidedWithBrick=true;
+          }
+        }else{
+          const bounds=getActiveBossBounds();
+          if(bounds){
+            const rx=bounds.x, ry=bounds.y, rw=bounds.w, rh=bounds.h;
+            if(b.x+r>rx && b.x-r<rx+rw && b.y+r>ry && b.y-r<ry+rh){
+              const oL=(b.x+r)-rx, oR=(rx+rw)-(b.x-r), oT=(b.y+r)-ry, oB=(ry+rh)-(b.y-r);
+              const m=Math.min(oL,oR,oT,oB);
+              let bounceAxis=null;
+              if(!inRampage && !b.piercing){
+                if(m===oL){ b.x=rx-r; b.vx=-Math.abs(b.vx)||-4; bounceAxis='x'; }
+                else if(m===oR){ b.x=rx+rw+r; b.vx=Math.abs(b.vx)||4; bounceAxis='x'; }
+                else if(m===oT){ b.y=ry-r; b.vy=-Math.abs(b.vy)||-4; bounceAxis='y'; }
+                else { b.y=ry+rh+r; b.vy=Math.abs(b.vy)||4; bounceAxis='y'; }
+              }else{
+                if(m===oL){ b.x=rx-r; b.vx=Math.abs(b.vx)||4; bounceAxis='x'; }
+                else if(m===oR){ b.x=rx+rw+r; b.vx=-Math.abs(b.vx)||-4; bounceAxis='x'; }
+                else if(m===oT){ b.y=ry-r; b.vy=Math.abs(b.vy)||4; bounceAxis='y'; }
+                else { b.y=ry+rh+r; b.vy=-Math.abs(b.vy)||-4; bounceAxis='y'; }
+                b.piercing=true;
+              }
+              if(bounceAxis){ noteBounce(b,b.x,b.y,bounceAxis,now); }
+              const impactX = Math.max(rx, Math.min(b.x, rx+rw));
+              const impactY = Math.max(ry, Math.min(b.y, ry+rh));
+              spawnParticles(impactX, impactY, '#b8d6ff', 20, 1.4, 2.4, 2.2);
+              fireCollide();
+              damageActiveBoss(1,'ball',{x:impactX,y:impactY});
+              collidedWithBrick=true;
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary
- shrink and redesign the dragon boss head with more intricate mechanical detailing to better match the reference art
- compute multi-part hit zones for the dragon so wings, limbs, tail, and head all register collisions, and update ball handling to use the new zones
- trigger the same active-ball buff effects when hitting the dragon boss that would trigger on bricks, including plasma, holy, freeze, and hell impacts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cecaf9926c8328bfa66908eb69d68b