### PR TITLE
Enhance dragon petrify charge visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -5323,23 +5323,67 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
       chargeProgress=Math.max(0, Math.min(1,(now-charge.start)/duration));
     }
     if(chargeProgress>0){
+      const pulse=0.55+Math.sin(now/140)*0.45;
       ctx.save();
       ctx.globalCompositeOperation='lighter';
-      ctx.globalAlpha=0.35+0.45*chargeProgress;
-      const bodyGlow=ctx.createRadialGradient(0,-20,40,0,-20,220);
-      bodyGlow.addColorStop(0,'rgba(255,180,120,1)');
-      bodyGlow.addColorStop(1,'rgba(255,60,20,0)');
-      ctx.fillStyle=bodyGlow;
+      ctx.shadowColor=`rgba(255,210,160,${0.55+0.35*chargeProgress})`;
+      ctx.shadowBlur=36+chargeProgress*32;
+
+      const auraRadius=220 + 160*chargeProgress + pulse*30;
+      const coreGlow=ctx.createRadialGradient(0,-32,0,0,-32,auraRadius);
+      coreGlow.addColorStop(0,'rgba(255,244,222,0.95)');
+      coreGlow.addColorStop(0.35,'rgba(255,208,150,0.8)');
+      coreGlow.addColorStop(0.75,'rgba(255,150,60,0.36)');
+      coreGlow.addColorStop(1,'rgba(255,90,30,0)');
+      ctx.fillStyle=coreGlow;
+      ctx.globalAlpha=0.55+0.4*chargeProgress;
       ctx.beginPath();
-      ctx.ellipse(0,20,180,240,0,0,Math.PI*2);
+      ctx.ellipse(0,8,auraRadius*0.55,auraRadius*0.78,0,0,Math.PI*2);
       ctx.fill();
-      ctx.shadowColor=`rgba(255,170,120,${0.65+0.3*chargeProgress})`;
-      ctx.shadowBlur=48;
-      ctx.strokeStyle=`rgba(255,210,140,${0.4+0.3*chargeProgress})`;
-      ctx.lineWidth=6;
+
+      const haloRadius=140 + 120*chargeProgress + pulse*18;
+      ctx.globalAlpha=0.85;
+      ctx.lineWidth=6.5 + chargeProgress*3.5;
+      ctx.strokeStyle=`rgba(255,220,170,${0.55+0.3*pulse})`;
       ctx.beginPath();
-      ctx.ellipse(0,-36,128,170,0,0,Math.PI*2);
+      ctx.ellipse(0,-46,haloRadius*0.6,haloRadius*0.84,0,0,Math.PI*2);
       ctx.stroke();
+
+      const filamentCount=6;
+      for(let i=0;i<filamentCount;i++){
+        const ang=(now/420) + i*(Math.PI*2/filamentCount);
+        const reach=160 + chargeProgress*180 + pulse*20;
+        ctx.save();
+        ctx.rotate(ang);
+        ctx.translate(0,-24);
+        ctx.globalAlpha=0.55+0.35*chargeProgress;
+        ctx.strokeStyle=`rgba(255,228,190,${0.45+0.25*pulse})`;
+        ctx.lineWidth=4.5 + chargeProgress*2.8;
+        ctx.beginPath();
+        ctx.moveTo(0,-28);
+        ctx.quadraticCurveTo(reach*0.28,-reach*0.62,reach,0);
+        ctx.quadraticCurveTo(reach*0.36,reach*0.48,reach*0.08,reach*0.74);
+        ctx.stroke();
+        ctx.restore();
+      }
+
+      const sparkCount=12;
+      ctx.globalAlpha=0.65;
+      for(let i=0;i<sparkCount;i++){
+        const ang=(now/260) + i*(Math.PI*2/sparkCount);
+        const radius=haloRadius + 50 + Math.sin(now/180 + i)*26*chargeProgress;
+        const sx=Math.cos(ang)*radius;
+        const sy=Math.sin(ang)*radius*0.88 - 18;
+        ctx.save();
+        ctx.translate(sx, sy);
+        ctx.rotate(ang);
+        ctx.fillStyle='rgba(255,255,255,0.9)';
+        ctx.beginPath();
+        ctx.ellipse(0,0,6 + chargeProgress*3.2,2.6 + chargeProgress*1.4,0,0,Math.PI*2);
+        ctx.fill();
+        ctx.restore();
+      }
+
       ctx.restore();
     }
     ctx.save();
@@ -8112,9 +8156,11 @@ function generateLevel(lv, L){
 
       // Boss wind-up glow
       if(bossChargeUntil && performance.now()<bossChargeUntil){
-      const a = 0.5 + 0.5*Math.sin(performance.now()/80);
+      const nowCharge = performance.now();
+      const a = 0.5 + 0.5*Math.sin(nowCharge/80);
+      const dragonCharging = isDragonActive() && dragonBoss && dragonBoss.petrifyCharge && nowCharge < dragonBoss.petrifyCharge.end;
       for(const b of bricks){ if(b.boss){ ctx.save(); ctx.globalCompositeOperation='lighter'; ctx.strokeStyle='rgba('+bossChargeColor+','+(0.6*a)+')'; ctx.lineWidth=4; drawRoundedRect(b.x,b.y,b.w,b.h,10); ctx.stroke(); ctx.restore(); } }
-      if(isDragonActive() && dragonBoss){ const bounds=getDragonBounds(); if(bounds){ ctx.save(); ctx.globalCompositeOperation='lighter'; ctx.strokeStyle='rgba('+bossChargeColor+','+(0.6*a)+')'; ctx.lineWidth=4; drawRoundedRect(bounds.x, bounds.y, bounds.w, bounds.h, 18); ctx.stroke(); ctx.restore(); } }
+      if(isDragonActive() && dragonBoss){ const bounds=getDragonBounds(); if(bounds && !dragonCharging){ ctx.save(); ctx.globalCompositeOperation='lighter'; ctx.strokeStyle='rgba('+bossChargeColor+','+(0.6*a)+')'; ctx.lineWidth=4; drawRoundedRect(bounds.x, bounds.y, bounds.w, bounds.h, 18); ctx.stroke(); ctx.restore(); } }
     }
 
 


### PR DESCRIPTION
## Summary
- replace the petrify beam wind-up effect with layered auras, halos, filaments, and sparks for a richer presentation
- stop drawing the temporary rectangular charge frame while the dragon channels its petrify beam

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cef939f0cc83288baad84e6321fd04