### PR TITLE
Adjust dragon boss HP and drops

### DIFF
--- a/index.html
+++ b/index.html
@@ -1298,7 +1298,7 @@ select optgroup { color: #0b1022; }
   const SPACE_BOSS_GUN_FIRE_RATE = 100; // ms between each burst per gun
   const SPACE_BOSS_GUN_FIRE_DURATION = 3000;
   const SPACE_BOSS_LASER_SWEEP_DURATION = 2000;
-  const DRAGON_MAX_HP = 50;
+  const DRAGON_MAX_HP = 80;
   const DRAGON_BASE_MODEL_WIDTH = 260;
   let spaceBossPhase='inactive';
   let spaceBoss=null;
@@ -5219,6 +5219,9 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
     updateHUD();
     screenShake=Math.max(screenShake,20);
     playSFX('fireExplosion');
+    const dropX=(dragonBoss?dragonBoss.x:550)-12;
+    const dropY=dragonBoss?dragonBoss.y:300;
+    spawnPower(dropX, dropY, {forceType:'NINE'});
   }
 
   function updateDragonBoss(){


### PR DESCRIPTION
## Summary
- increase the Destruction Dragon boss maximum health to 80
- guarantee the Destruction Dragon drops the 9-Life Cat power when defeated

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf6c4da9088328b4d952f7446558e2