### PR TITLE
Adjust level 15 petrify timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -3161,7 +3161,11 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
     }
     // 重置 Boss 計時
     nextBossAtkA = nextBossAtkB = bossChargeUntil = cyclopsShakeUntil = 0; bossChargeColor='';
-    if(level===15){ cyclopsForcedPetrifyAt = performance.now() + 10000; }
+    if(level===15){
+      // The cyclops boss takes 3 seconds to charge before firing the petrify column.
+      // Schedule the forced cast so that the beam lands exactly 5 seconds after entry.
+      cyclopsForcedPetrifyAt = performance.now() + 2000;
+    }
   }
 
   


### PR DESCRIPTION
## Summary
- trigger the cyclops boss's forced petrify beam earlier so it lands 5 seconds after entering stage 15

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cff639813c83288ee1f87ef45376ad