### PR TITLE
Ensure cyclops petrify event resets when re-entering level 15

### DIFF
--- a/index.html
+++ b/index.html
@@ -3223,8 +3223,11 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
     dragonNextAttackAt=0;
     dragonDeathRayOrbs.length=0;
     dragonDeathRayBeams.length=0;
-    dragonPhase = (level===15?'awaiting':'inactive');
-    cyclopsFirstAttackAt=0;
+      dragonPhase = (level===15?'awaiting':'inactive');
+      // Reset Cyclops/dragon forced petrify trigger so level 15 always re-schedules it
+      cyclopsForcedPetrifyAt=0;
+      cyclopsForcedPetrifyFired=false;
+      cyclopsFirstAttackAt=0;
     cyclopsEventStarted=false;
     cyclopsMarqueeShown=false;
     cyclopsRowBlastIndex=-1;


### PR DESCRIPTION
## Summary
- reset the Cyclops petrify timing flags when initializing a level so level 15 always schedules the forced beam

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0069e16b4832883ded1dfe2ab1129