### PR TITLE
Revamp level 20 boss reveal sequence

### DIFF
--- a/index.html
+++ b/index.html
@@ -1372,6 +1372,19 @@ select optgroup { color: #0b1022; }
   let dragonNextAttackAt=0;
   const dragonDeathRayOrbs=[];
   const dragonDeathRayBeams=[];
+  let demonShellBrick=null;
+  let demonEventPhase='inactive';
+  let demonEventTimerStart=0;
+  let demonEventTriggeredAt=0;
+  let demonEventMarquee=null;
+  let demonEventWave=null;
+  let demonEventRows=[];
+  let demonEventNextRowAt=0;
+  let demonFallingDebris=[];
+  let demonEventShakeUntil=0;
+  let demonCore=null;
+  let demonEventTargets=0;
+  let demonEventCleared=0;
 
   function isSpaceBossActive(){
     return level===5 && spaceBossPhase==='active' && !!spaceBoss;
@@ -2326,6 +2339,235 @@ select optgroup { color: #0b1022; }
       }
     }
   }
+
+  function prepareDemonRows(){
+    const L=layout();
+    const spacing = brickH + L.pad;
+    const rowsMap=new Map();
+    for(const b of bricks){
+      if(b.demonShell) continue;
+      if(b.fallingTreasure) continue;
+      const row=Math.round((b.y - L.top)/spacing);
+      if(!rowsMap.has(row)) rowsMap.set(row, []);
+      rowsMap.get(row).push(b);
+    }
+    demonEventRows = Array.from(rowsMap.entries())
+      .sort((a,b)=>b[0]-a[0])
+      .map(([,arr])=>arr);
+    demonEventTargets = demonEventRows.reduce((sum,row)=>sum+row.length,0);
+    demonEventCleared=0;
+  }
+
+  function dropDemonRow(row, now){
+    if(!Array.isArray(row)) return;
+    const debris=[];
+    for(const brick of row){
+      const idx=bricks.indexOf(brick);
+      if(idx<0) continue;
+      revealBrickArea(brick);
+      bricks.splice(idx,1);
+      demonEventCleared++;
+      const baseColor = brick.treasure ? '#ffd166' : brick.boss ? '#ff4d6d' : brick.unbreakable ? '#888888' : brick.strong ? '#bb7aff' : brick.moving ? '#6ec6ff' : brick.explosive ? getVar('--expl') : brickColor(brick.colorIdx||0);
+      debris.push({
+        x:brick.x,
+        y:brick.y,
+        w:brick.w,
+        h:brick.h,
+        color:baseColor,
+        treasure:!!brick.treasure,
+        vy:1.4 + Math.random()*1.3,
+        gravity:0.12 + Math.random()*0.05,
+        angle:(Math.random()-0.5)*0.2,
+        spin:(Math.random()-0.5)*0.05
+      });
+    }
+    if(debris.length){
+      demonFallingDebris.push(...debris);
+      screenShake=Math.max(screenShake,16);
+    }
+    if(row){ row.length=0; }
+  }
+
+  function startDemonEvent(now){
+    if(demonEventPhase!=='awaiting') return;
+    demonEventPhase='collapse';
+    demonEventTriggeredAt=now;
+    const shell=demonShellBrick;
+    const cx=shell? shell.x + shell.w/2 : 1100/2;
+    const cy=shell? shell.y + shell.h/2 : layout().top;
+    demonEventMarquee={
+      text:'跪伏於我的力量之下吧!',
+      start:now,
+      fadeStart:now+5000,
+      end:now+8000
+    };
+    demonEventWave={x:cx, y:cy, start:now, duration:3200, maxRadius:Math.hypot(1100,700)};
+    demonEventShakeUntil = now + 6000;
+    prepareDemonRows();
+    demonEventNextRowAt=now;
+    if(demonEventTargets===0){
+      explodeDemonShell(now);
+      return;
+    }
+    screenShake=Math.max(screenShake,20);
+  }
+
+  function explodeDemonShell(now){
+    if(!demonShellBrick) return;
+    const shell=demonShellBrick;
+    const idx=bricks.indexOf(shell);
+    if(idx>=0) bricks.splice(idx,1);
+    const cx=shell.x + shell.w/2;
+    const cy=shell.y + shell.h/2;
+    spawnParticles(cx,cy,'#fff5d6',120,3.2,5.0,5.5);
+    spawnParticles(cx,cy,'#8a6bff',90,2.6,4.2,4.6);
+    spawnParticles(cx,cy,'#d476ff',70,2.3,3.8,4.2);
+    demonEventWave={x:cx,y:cy,start:now,duration:2600,maxRadius:Math.hypot(1100,700)};
+    demonCore={x:cx,y:cy,start:now,visibleUntil:now+4000};
+    screenShake=Math.max(screenShake,22);
+    demonShellBrick=null;
+    demonEventPhase='revealed';
+  }
+
+  function updateDemonEvent(now){
+    if(level!==20){
+      return;
+    }
+    if(demonEventPhase==='awaiting'){
+      if(running && !paused && !resumePending){
+        if(!demonEventTimerStart){
+          demonEventTimerStart=now;
+        }else if(now - demonEventTimerStart >= 10000){
+          startDemonEvent(now);
+        }
+      }
+    }else if(demonEventPhase==='collapse'){
+      if(demonEventRows.length && now>=demonEventNextRowAt){
+        const row=demonEventRows.shift();
+        dropDemonRow(row, now);
+        demonEventNextRowAt = now + 5000;
+      }
+      if(demonEventTargets>0 && demonEventCleared>=demonEventTargets){
+        explodeDemonShell(now);
+      }
+    }else if(demonEventPhase==='revealed'){
+      if(demonCore && now>=demonCore.visibleUntil){
+        demonCore=null;
+        demonEventPhase='complete';
+      }
+    }
+
+    if(demonEventMarquee && now>=demonEventMarquee.end){
+      demonEventMarquee=null;
+    }
+    if(demonEventWave && now>=demonEventWave.start + demonEventWave.duration){
+      demonEventWave=null;
+    }
+    if(demonEventShakeUntil && now<demonEventShakeUntil){
+      screenShake=Math.max(screenShake,18);
+    }
+  }
+
+  function drawDemonMarquee(now){
+    if(level!==20 || !demonEventMarquee) return;
+    const evt=demonEventMarquee;
+    if(now<evt.start) return;
+    const duration=Math.max(1, evt.end-evt.fadeStart);
+    const alpha = now<evt.fadeStart ? 1 : Math.max(0, 1 - (now-evt.fadeStart)/duration);
+    if(alpha<=0) return;
+    const L=layout();
+    const barHeight = 48*((scaleX+scaleY)/2);
+    const barWidth = canvas.width*0.7;
+    const barX = (canvas.width-barWidth)/2;
+    const barY = Math.max(12, L.top*scaleY - barHeight - 20);
+    const radius = 18*((scaleX+scaleY)/2);
+    ctx.save();
+    ctx.globalAlpha=alpha;
+    const bgGrad=ctx.createLinearGradient(barX, barY, barX, barY+barHeight);
+    bgGrad.addColorStop(0,'rgba(90,30,140,0.85)');
+    bgGrad.addColorStop(1,'rgba(40,10,80,0.9)');
+    ctx.fillStyle=bgGrad;
+    ctx.beginPath();
+    ctx.moveTo(barX+radius, barY);
+    ctx.lineTo(barX+barWidth-radius, barY);
+    ctx.quadraticCurveTo(barX+barWidth, barY, barX+barWidth, barY+radius);
+    ctx.lineTo(barX+barWidth, barY+barHeight-radius);
+    ctx.quadraticCurveTo(barX+barWidth, barY+barHeight, barX+barWidth-radius, barY+barHeight);
+    ctx.lineTo(barX+radius, barY+barHeight);
+    ctx.quadraticCurveTo(barX, barY+barHeight, barX, barY+barHeight-radius);
+    ctx.lineTo(barX, barY+radius);
+    ctx.quadraticCurveTo(barX, barY, barX+radius, barY);
+    ctx.closePath();
+    ctx.fill();
+    ctx.strokeStyle='rgba(210,150,255,0.85)';
+    ctx.lineWidth=2.5*((scaleX+scaleY)/2);
+    ctx.stroke();
+
+    const fontSize = Math.round(26*((scaleX+scaleY)/2));
+    ctx.font=`${fontSize}px 'Playfair Display','Noto Sans TC',sans-serif`;
+    ctx.fillStyle='rgba(255,235,255,0.95)';
+    ctx.textBaseline='middle';
+    const textWidth=ctx.measureText(evt.text).width;
+    const travel=barWidth + textWidth + 40;
+    const t=Math.min(1, (now-evt.start)/5000);
+    const textX = barX + barWidth + 20 - travel*t;
+    const textY = barY + barHeight/2;
+    ctx.fillText(evt.text, textX, textY);
+    ctx.restore();
+  }
+
+  function drawDemonWave(now){
+    if(level!==20 || !demonEventWave) return;
+    const wave=demonEventWave;
+    const life = wave.duration||1;
+    const prog = Math.max(0, Math.min(1,(now-wave.start)/life));
+    const radius = (wave.maxRadius||Math.hypot(1100,700)) * prog;
+    const alpha = 0.35*(1-prog);
+    if(alpha<=0) return;
+    ctx.save();
+    ctx.globalCompositeOperation='lighter';
+    const maxR = radius*((scaleX+scaleY)/2);
+    const minR = maxR*0.35;
+    const grad=ctx.createRadialGradient(wave.x*scaleX, wave.y*scaleY, minR, wave.x*scaleX, wave.y*scaleY, Math.max(minR+1,maxR));
+    grad.addColorStop(0,`rgba(180,120,255,${alpha})`);
+    grad.addColorStop(0.65,`rgba(120,50,200,${alpha*0.6})`);
+    grad.addColorStop(1,'rgba(80,20,160,0)');
+    ctx.fillStyle=grad;
+    ctx.beginPath();
+    ctx.arc(wave.x*scaleX, wave.y*scaleY, Math.max(minR+1,maxR),0,Math.PI*2);
+    ctx.fill();
+    ctx.restore();
+  }
+
+  function drawDemonCore(now){
+    if(level!==20 || !demonCore) return;
+    const life = demonCore.visibleUntil ? Math.max(1, demonCore.visibleUntil - demonCore.start) : 1;
+    const remain = demonCore.visibleUntil ? Math.max(0, demonCore.visibleUntil - now) : life;
+    const alpha = Math.max(0, Math.min(1, remain/life));
+    const baseRadius = 34*((scaleX+scaleY)/2);
+    const pulse = 1 + 0.08*Math.sin(now/160);
+    const outer = baseRadius*1.6*pulse;
+    const cx=demonCore.x*scaleX;
+    const cy=demonCore.y*scaleY;
+    ctx.save();
+    ctx.globalCompositeOperation='lighter';
+    const glow=ctx.createRadialGradient(cx, cy, 0, cx, cy, outer);
+    glow.addColorStop(0,`rgba(230,210,255,${0.6*alpha})`);
+    glow.addColorStop(0.45,`rgba(170,100,255,${0.45*alpha})`);
+    glow.addColorStop(1,'rgba(90,30,200,0)');
+    ctx.fillStyle=glow;
+    ctx.beginPath();
+    ctx.arc(cx,cy,outer,0,Math.PI*2);
+    ctx.fill();
+    ctx.restore();
+
+    ctx.save();
+    ctx.fillStyle=`rgba(200,120,255,${0.9*alpha})`;
+    ctx.beginPath();
+    ctx.arc(cx,cy,baseRadius*pulse,0,Math.PI*2);
+    ctx.fill();
+    ctx.restore();
+  }
   function cyclopsBlastRow(rowIndex){
     const L=layout();
     const rowHeight = brickH + L.pad;
@@ -2372,7 +2614,7 @@ select optgroup { color: #0b1022; }
       if(dragonPhase!=='awaiting'){ cyclopsForcedPetrifyFired=true; cyclopsForcedPetrifyAt=0; }
       maybeStartDragonAttack(now);
     }
-    else if(bossLv===20){ if(now>=nextBossAtkA){ spawnDemonBeam(); nextBossAtkA = now + 10000; } if(now>=nextBossAtkB){ spawnDemonClouds(); nextBossAtkB = now + 30000; } }
+    else if(bossLv===20){ /* 第20關新事件期間暫停原有攻擊 */ }
   }
 
   function drawAndStepBossProjectiles(){
@@ -3249,6 +3491,19 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
     cyclopsNextRowBlast=0;
     cyclopsShellBurst=false;
     cyclopsEventComplete=false;
+    demonShellBrick=null;
+    demonEventPhase = (level===20?'awaiting':'inactive');
+    demonEventTimerStart=0;
+    demonEventTriggeredAt=0;
+    demonEventMarquee=null;
+    demonEventWave=null;
+    demonEventRows=[];
+    demonEventNextRowAt=0;
+    demonFallingDebris=[];
+    demonEventShakeUntil=0;
+    demonCore=null;
+    demonEventTargets=0;
+    demonEventCleared=0;
     const lvlImg = getLevelImage(level);
     if (lvlImg && lvlImg.decode) { lvlImg.decode().catch(()=>{}); }
     // 依關卡設計關卡布局
@@ -3311,6 +3566,12 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
       if(dragonPhase==='defeated' && dragonDefeatedAt && now < dragonDefeatedAt + 3000){
         return true;
       }
+      return false;
+    }
+    if(level===20){
+      const remaining = bricks.some(b => !b.unbreakable && !b.demonShell);
+      if(remaining) return true;
+      if(demonEventPhase && demonEventPhase!=='inactive' && demonEventPhase!=='complete') return true;
       return false;
     }
     return bricks.some(b => !b.unbreakable);
@@ -7379,6 +7640,19 @@ function generateLevel(lv, L){
           }
         }
         return;
+      }else if(lv===20){
+        const by = 0;
+        const placeholderIndex=bricks.length;
+        addBrick(bricks, xAt(bx), yAt(by), w, h, {hp:Infinity, colorIdx:0, boss:true, face:faces[bossIdx], strong:true, unbreakable:true, demonShell:true, hideBossHP:true});
+        demonShellBrick = bricks[placeholderIndex];
+        for(let r=0;r<rows;r++){
+          for(let c=0;c<cols;c++){
+            if(c>=bx && c<=bx+1 && r===by) continue;
+            const explosive=Math.random()<GAME_CONFIG.bricks.explosiveChance;
+            addBrick(bricks, xAt(c), yAt(r), brickW, brickH, {hp:baseHP, colorIdx:(r%4), explosive});
+          }
+        }
+        return;
       }
       const by = Math.max(1, Math.floor(rows/2)-1);
       addBrick(bricks, xAt(bx), yAt(by), w, h, {hp:bossHP, colorIdx:0, boss:true, face:faces[bossIdx], strong:true, unbreakable:true});
@@ -8590,7 +8864,9 @@ function generateLevel(lv, L){
   function draw(){
     if(screenShake>0){ const s=screenShake*0.6; ctx.save(); ctx.translate((Math.random()-0.5)*s,(Math.random()-0.5)*s); screenShake*=0.9; }
     ctx.clearRect(0,0,canvas.width,canvas.height);
+    const now=performance.now();
     drawBGDecor();
+    drawDemonWave(now);
     if(buffs.ANNIHIL.active){ if(Math.random()<0.5) annihilSparks.push({x:Math.random()*1100,y:0,v:1+Math.random()*1.5}); for(let i=annihilSparks.length-1;i>=0;i--){ const sp=annihilSparks[i]; sp.y+=sp.v; ctx.fillStyle='rgba(255,220,150,0.8)'; ctx.fillRect(sp.x*scaleX, sp.y*scaleY,2*scaleX,2*scaleY); if(sp.y>700) annihilSparks.splice(i,1); } }
     drawRevealTiles();
 
@@ -8674,7 +8950,7 @@ function generateLevel(lv, L){
       // 血條 / 面孔
       if(b.boss){
         drawBossEmblem(b);
-        if(!b.cyclops){
+        if(!b.cyclops && !b.hideBossHP){
           // 血條
           ctx.fillStyle='rgba(0,0,0,.45)'; ctx.fillRect((b.x+8)*scaleX,(b.y+b.h-8)*scaleY,(b.w-16)*scaleX,6*scaleY);
           const ratio=Math.max(0, b.hp/40);
@@ -8688,9 +8964,32 @@ function generateLevel(lv, L){
       }
     }
 
+    for(const d of demonFallingDebris){
+      ctx.save();
+      const cx=(d.x + d.w/2)*scaleX;
+      const cy=(d.y + d.h/2)*scaleY;
+      ctx.translate(cx, cy);
+      ctx.rotate(d.angle);
+      const w=d.w*scaleX;
+      const h=d.h*scaleY;
+      const grad=ctx.createLinearGradient(0,-h/2,0,h/2);
+      grad.addColorStop(0,d.color||'#ffffff');
+      grad.addColorStop(1,'rgba(26,31,58,0.85)');
+      ctx.fillStyle=grad;
+      ctx.beginPath();
+      ctx.moveTo(-w/2,-h/2);
+      ctx.lineTo(w/2,-h/2);
+      ctx.lineTo(w/2,h/2);
+      ctx.lineTo(-w/2,h/2);
+      ctx.closePath();
+      ctx.fill();
+      ctx.restore();
+    }
+
     drawSpaceBossLayer();
     drawReaperLayer();
     drawDragonLayer();
+    drawDemonCore(now);
     drawPlasmas(); drawHoly(); drawPhoenix(); drawSwords();
 
       // Boss wind-up glow
@@ -8918,6 +9217,7 @@ function generateLevel(lv, L){
     drawSpaceBossHUD();
     drawReaperHUD();
     drawDragonHUD();
+    drawDemonMarquee(now);
 
     // 倒數提示
     if(countdownShow>0){
@@ -9100,6 +9400,7 @@ function generateLevel(lv, L){
     updateSpaceBoss();
     updateReaperBoss();
     updateDragonBoss();
+    updateDemonEvent(now);
 
     if(isTrueBossFightActive()){
       if(!nextTreasureBrickAt){
@@ -9121,6 +9422,14 @@ function generateLevel(lv, L){
       if(bk.y>710){ bricks.splice(i,1); treasureRemoved=true; }
     }
     if(treasureRemoved){ updateHUD(); }
+
+    for(let i=demonFallingDebris.length-1;i>=0;i--){
+      const d=demonFallingDebris[i];
+      d.vy += d.gravity;
+      d.y += d.vy;
+      d.angle += d.spin;
+      if(d.y>720){ demonFallingDebris.splice(i,1); }
+    }
 
     // 劇毒磚持續扣血
     for(let i=bricks.length-1;i>=0;i--){


### PR DESCRIPTION
## Summary
- move the level 20 boss shell to the top row, hide its health bar, and initialise new event state when generating the level
- script a timed reveal sequence that triggers a marquee, purple shockwave, cascading brick collapse, and shell explosion exposing a temporary core
- render the marquee, wave, falling debris, and core visuals while suppressing the previous level-20 boss attack routines

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d02c43cf748328ab6966b64ca732c5