### PR TITLE
Fix demon boss rendering context restore

### DIFF
--- a/index.html
+++ b/index.html
@@ -3245,6 +3245,8 @@ select optgroup { color: #0b1022; }
     ctx.restore();
 
     ctx.restore();
+
+    ctx.restore();
   }
 
 


### PR DESCRIPTION
## Summary
- add the missing `ctx.restore()` at the end of `renderDemonFigure` so the canvas state is restored after drawing the demon boss
- ensures subsequent game elements render in the correct position when the demon boss appears

## Testing
- Manual verification: opened level 20 and confirmed the demon boss fight keeps the arena within view

------
https://chatgpt.com/codex/tasks/task_e_68d2a8a0b6a4832891defc25f9caa845