### PR TITLE
Adjust level 20 marquee to match dragon boss styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -2466,10 +2466,11 @@ select optgroup { color: #0b1022; }
     const cx=shell? shell.x + shell.w/2 : 1100/2;
     const cy=shell? shell.y + shell.h/2 : layout().top;
     demonEventMarquee={
-      text:'跪伏於我的力量之下吧！',
+      text:'跪伏於我的力量之下吧!',
       start:now,
       fadeStart:now+5000,
-      end:now+8000
+      end:now+8000,
+      style:'elegant'
     };
     demonEventWave={x:cx, y:cy, start:now, duration:2000, maxRadius:Math.hypot(1100,700)};
     demonEventShakeUntil = now + 7000;
@@ -2545,46 +2546,61 @@ select optgroup { color: #0b1022; }
     if(level!==20 || !demonEventMarquee) return;
     const evt=demonEventMarquee;
     if(now<evt.start) return;
-    const duration=Math.max(1, evt.end-evt.fadeStart);
-    const alpha = now<evt.fadeStart ? 1 : Math.max(0, 1 - (now-evt.fadeStart)/duration);
+    if(now>=evt.end){
+      demonEventMarquee=null;
+      return;
+    }
+    let alpha=1;
+    if(evt.fadeStart && now>evt.fadeStart){
+      const span=Math.max(1, evt.end - evt.fadeStart);
+      alpha=Math.max(0, 1 - (now - evt.fadeStart)/span);
+    }
     if(alpha<=0) return;
     const L=layout();
-    const barHeight = 48*((scaleX+scaleY)/2);
-    const barWidth = canvas.width*0.7;
-    const barX = (canvas.width-barWidth)/2;
-    const barY = Math.max(12, L.top*scaleY - barHeight - 20);
+    const areaHeight=60;
+    const top=Math.max(16, L.top - areaHeight - 14);
+    const width=Math.min(560, 1100-120);
+    const x=(1100-width)/2;
+    const radius=20;
     ctx.save();
     ctx.globalAlpha=alpha;
-    const fontSize = Math.round(26*((scaleX+scaleY)/2));
-    ctx.font=`${fontSize}px 'Playfair Display','Noto Sans TC',sans-serif`;
-    const glowGrad=ctx.createLinearGradient(barX, barY, barX+barWidth, barY);
-    glowGrad.addColorStop(0,'rgba(255,240,255,0.85)');
-    glowGrad.addColorStop(0.5,'rgba(220,190,255,0.95)');
-    glowGrad.addColorStop(1,'rgba(255,240,255,0.85)');
-    ctx.fillStyle=glowGrad;
+    drawRoundedRect(x, top, width, areaHeight, radius);
+    const grad=ctx.createLinearGradient(x*scaleX, top*scaleY, x*scaleX, (top+areaHeight)*scaleY);
+    grad.addColorStop(0,'rgba(48,22,10,0.9)');
+    grad.addColorStop(1,'rgba(28,12,6,0.88)');
+    ctx.fillStyle=grad;
+    ctx.fill();
+    ctx.strokeStyle='rgba(255,210,150,0.85)';
+    ctx.lineWidth=2.4;
+    drawRoundedRect(x, top, width, areaHeight, radius);
+    ctx.stroke();
+    const innerX=x+10;
+    const innerY=top+6;
+    const innerW=width-20;
+    const innerH=areaHeight-12;
+    ctx.save();
+    drawRoundedRect(innerX, innerY, innerW, innerH, radius-6);
+    const innerGrad=ctx.createLinearGradient(innerX*scaleX, innerY*scaleY, innerX*scaleX, (innerY+innerH)*scaleY);
+    innerGrad.addColorStop(0,'rgba(140,70,30,0.45)');
+    innerGrad.addColorStop(1,'rgba(80,34,14,0.35)');
+    ctx.fillStyle=innerGrad;
+    ctx.fill();
+    ctx.strokeStyle='rgba(255,220,180,0.45)';
+    ctx.lineWidth=1.4;
+    ctx.stroke();
+    ctx.restore();
+    ctx.save();
+    drawRoundedRect(innerX, innerY, innerW, innerH, radius-6);
+    ctx.clip();
+    ctx.fillStyle='#ffeedd';
+    const fontSize=Math.max(20, Math.round(26*((scaleX+scaleY)/2)));
+    ctx.font=`${fontSize}px 'Playfair Display','Noto Sans TC',serif`;
+    ctx.textAlign='center';
     ctx.textBaseline='middle';
-    const textWidth=ctx.measureText(evt.text).width;
-    const travel=barWidth + textWidth + 40;
-    const t=Math.min(1, (now-evt.start)/5000);
-    const textX = barX + barWidth + 20 - travel*t;
-    const textY = barY + barHeight/2;
-    ctx.shadowColor='rgba(205,160,255,0.75)';
-    ctx.shadowBlur=24*((scaleX+scaleY)/2);
-    ctx.fillText(evt.text, textX, textY);
-    ctx.shadowBlur=0;
-    ctx.lineWidth=2*((scaleX+scaleY)/2);
-    ctx.strokeStyle='rgba(210,160,255,0.45)';
-    ctx.beginPath();
-    ctx.moveTo(barX, textY + fontSize*0.36);
-    ctx.lineTo(barX+barWidth, textY + fontSize*0.36);
-    ctx.stroke();
-    ctx.globalCompositeOperation='lighter';
-    ctx.strokeStyle='rgba(255,230,255,0.25)';
-    ctx.lineWidth=1.2*((scaleX+scaleY)/2);
-    ctx.beginPath();
-    ctx.moveTo(barX, textY - fontSize*0.42);
-    ctx.lineTo(barX+barWidth, textY - fontSize*0.42);
-    ctx.stroke();
+    ctx.shadowColor='rgba(255,150,110,0.55)';
+    ctx.shadowBlur=14*((scaleX+scaleY)/2);
+    ctx.fillText(evt.text, (innerX+innerW/2)*scaleX, (innerY+innerH/2)*scaleY);
+    ctx.restore();
     ctx.restore();
   }
 


### PR DESCRIPTION
## Summary
- restyle the level 20 collapse marquee using the same elegant board look as the dragon boss
- keep the warning text while matching the dragon marquee timing and fade handling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3fc7a6d78832895ce4620e82e5b1a