### PR TITLE
Adjust demon boss eye proportions

### DIFF
--- a/index.html
+++ b/index.html
@@ -3437,8 +3437,9 @@ select optgroup { color: #0b1022; }
     ctx.stroke();
     ctx.restore();
 
-    const eyeBase=28;
-    const eyeLength=66;
+    const eyeScale=0.7;
+    const eyeBase=28*eyeScale;
+    const eyeLength=66*eyeScale;
     const eyeTilt=Math.PI/4;
     ctx.fillStyle=palette.eye;
     ctx.save();


### PR DESCRIPTION
## Summary
- scale 魔王埃里赫曼的眼睛幾何參數為原本的 70%，讓視覺比例更精實

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4d11fbb30832880daf8303101e49f