### PR TITLE
Adjust boss nameplate text colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -6210,7 +6210,7 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
       bgBottom:'rgba(18,28,60,0.9)',
       frame:'rgba(170,210,255,0.75)',
       glow:'rgba(140,200,255,0.6)',
-      textPrimary:'#e9f2ff',
+      textPrimary:'#000000',
       textSecondary:'#f0f5ff'
     });
     ctx.restore();
@@ -9303,7 +9303,7 @@ let balls=[]; function makeBall(stuck=false,x=null){ return {x:x??(1100/2),y:700
       bgBottom:'rgba(38,12,80,0.9)',
       frame:'rgba(230,190,255,0.7)',
       glow:'rgba(200,150,255,0.55)',
-      textPrimary:'#f1e4ff',
+      textPrimary:'#3a0066',
       textSecondary:'#f9efff'
     });
     ctx.restore();


### PR DESCRIPTION
## Summary
- set the Space Battleship boss name text to render in black
- update Demon Overlord Erihmann boss name text to use a deep purple tone

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d55d55fc888328801f8739fc620a9a