### PR TITLE
Shorten demon ritual spears and keep them breakable

### DIFF
--- a/index.html
+++ b/index.html
@@ -1826,7 +1826,7 @@ select optgroup { color: #0b1022; }
     const startY = overrides.startY ?? Math.max(0, L.top - 260);
     const baseWidth = lane.width || 60;
     const width = Math.max(24, overrides.width ?? baseWidth * 0.34);
-    const length = Math.max(220, overrides.length ?? (brickH||40)*3.8);
+    const length = Math.max(110, overrides.length ?? (brickH||40)*1.9);
     const tipScale = Math.max(0.12, Math.min(0.45, overrides.tipScale ?? 0.22));
     const spear={
       id: ++demonBlackSpearId,


### PR DESCRIPTION
## Summary
- halve the default length of demon ritual black spears so they no longer cover as much of the arena
- retain the existing collision logic so falling or stuck spears can still be broken by the ball and attack effects

## Testing
- No automated tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d6be0b1c948328993c7d694ab2edfc