### PR TITLE
Update Infinite Castle skin colors and iconography

### DIFF
--- a/index.html
+++ b/index.html
@@ -399,22 +399,49 @@ select optgroup { color: #0b1022; }
     }
     /* === 和風．無限之城 === */
     body[data-skin="和風．無限之城"]{
-      --ink:#ffedc2;
-      --muted:#cbb07a;
-      --stroke:rgba(247,227,174,.35);
-      --bg1:#130a00;
-      --bg2:#060300;
-      --hudGrad1:rgba(80,60,20,.55);
-      --hudGrad2:rgba(50,35,10,.45);
-      --glass-1:rgba(255,255,255,.08);
-      --glass-2:rgba(255,255,255,.05);
-      --stageGlass:linear-gradient(180deg, rgba(255,200,120,.07), transparent);
-      --panelPattern:none;
-      --btnGlow:0 0 20px rgba(255,200,120,.25);
+      --ink:#ffe8d4;
+      --muted:#d5b097;
+      --stroke:rgba(214,102,86,.38);
+      --bg1:#1a050c;
+      --bg2:#070106;
+      --hudGrad1:rgba(94,20,32,.62);
+      --hudGrad2:rgba(52,8,20,.5);
+      --glass-1:rgba(148,30,46,.24);
+      --glass-2:rgba(70,12,26,.32);
+      --stageGlass:linear-gradient(180deg, rgba(140,26,38,.08), rgba(0,0,0,0));
+      --panelPattern:repeating-linear-gradient(90deg, rgba(116,24,36,.10) 0 18px, rgba(116,24,36,0) 18px 36px),
+                      repeating-linear-gradient(0deg, rgba(74,14,24,.08) 0 16px, rgba(74,14,24,0) 16px 32px);
+      --btnGlow:0 0 22px rgba(220,72,84,.32);
+      --heartGlow:rgba(255,148,122,.35);
     }
     body[data-skin="和風．無限之城"] #game{
       /* 修正背景位置屬性拼寫錯誤，確保圖片正常顯示 */
       background:url("images/d1.JPG") center/cover no-repeat;
+    }
+    body[data-skin="和風．無限之城"] .hud,
+    body[data-skin="和風．無限之城"] #buffs .badge,
+    body[data-skin="和風．無限之城"] .pill,
+    body[data-skin="和風．無限之城"] #promptsDock .prompt,
+    body[data-skin="和風．無限之城"] .ic-btn,
+    body[data-skin="和風．無限之城"] .btn,
+    body[data-skin="和風．無限之城"] select,
+    body[data-skin="和風．無限之城"] input[type="range"]{
+      color:var(--ink);
+      border-color:var(--stroke);
+      background:linear-gradient(160deg, rgba(180,38,50,.26), rgba(58,10,18,.38));
+      box-shadow:inset 0 0 0 1px rgba(255,255,255,.04), 0 10px 26px rgba(0,0,0,.34), var(--btnGlow);
+    }
+    body[data-skin="和風．無限之城"] .menu{
+      background:rgba(30,6,12,.94);
+      border-color:var(--stroke);
+    }
+    body[data-skin="和風．無限之城"] .menu .item{
+      background:linear-gradient(160deg, rgba(160,30,44,.28), rgba(50,8,18,.4));
+      border-color:var(--stroke);
+    }
+    body[data-skin="和風．無限之城"] .level-select select option{
+      background:#2c0610;
+      color:var(--ink);
     }
 
 /* HUD/按鍵的霓虹語彙（按鍵邊緣流光＋心形光暈） */

--- a/skin.js
+++ b/skin.js
@@ -188,10 +188,14 @@
     label: '和風．無限之城',
     selectLabel: '和風．無限之城',
     cssSkin: '和風．無限之城',
-    lifeIcon: `<svg viewBox="0 0 32 32">
-      <path d="M2 4 L30 28 M2 4 l6-2 l2 6 M30 28 l-6 2 l-2-6"
-            stroke="#ffedc2" stroke-width="3" fill="none"
-            stroke-linecap="round" stroke-linejoin="round"/>
+    lifeIcon: `<svg viewBox="0 0 48 48" aria-hidden="true">
+      <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M6 38.5 L39.5 5" stroke="#fdf2da" stroke-width="3"/>
+        <path d="m34 11 4.2 4.2" stroke="#fef5e6" stroke-width="2.4"/>
+        <path d="m10.2 35 4.4 4.4" stroke="#431010" stroke-width="4.4"/>
+        <path d="m13.2 31.8 4 4" stroke="#b23a32" stroke-width="3.4"/>
+        <path d="m17.2 28.2 3.4 3.4" stroke="#fdf2da" stroke-width="2.2"/>
+      </g>
     </svg>`,
     canvas: {
       base: [210, 160, 70],


### PR DESCRIPTION
## Summary
- replace the Infinite Castle life indicator with a stylized katana icon
- retheme the Infinite Castle HUD, controls, and menus with a crimson wood inspired palette and glow accents

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6d5a613888328935aff9a015565a9