### PR TITLE
Refine infinite castle katana lives and paddle

### DIFF
--- a/index.html
+++ b/index.html
@@ -443,6 +443,20 @@ select optgroup { color: #0b1022; }
       background:#2c0610;
       color:var(--ink);
     }
+    body[data-skin="和風．無限之城"] .hearts .life-icon{
+      width:26px;
+      height:26px;
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+      margin:0 2px;
+      filter:drop-shadow(0 0 6px rgba(255,196,150,0.45));
+    }
+    body[data-skin="和風．無限之城"] .hearts .life-icon svg{
+      width:26px;
+      height:26px;
+      display:block;
+    }
 
 /* HUD/按鍵的霓虹語彙（按鍵邊緣流光＋心形光暈） */
 
@@ -11605,22 +11619,133 @@ function generateLevel(lv, L){
       const padGlow=buffs.STICKY.active?'rgba(120,230,220,.6)':((buffs.WIDE.active||buffs.LONG.stacks.length)?'rgba(120,170,255,.6)':'rgba(200,210,255,.4)');
       ctx.shadowColor=padGlow; ctx.shadowBlur=20;
       const padW=pr.w*scaleX, padH=pr.h*scaleY;
+      const scaleUnit=Math.min(scaleX,scaleY);
       ctx.save();
       ctx.translate((pr.x+pr.w/2)*scaleX,(pr.y+pr.h/2)*scaleY);
       let ang=0;
       if(buffs.PADSPIN.active){ const period=GAME_CONFIG.powers.PADSPIN.spin.periodMs||8000; ang=((nowPad-(buffs.PADSPIN.start||nowPad))%period)/period*2*Math.PI; }
       ctx.rotate(ang);
-      ctx.fillStyle='#9aaeff';
+      const isInfiniteCastle = window.currentSkin && window.currentSkin.cssSkin === '和風．無限之城';
+      const drawPadShape = () => {
+        ctx.beginPath();
+        ctx.moveTo(-padW/2 + r, -padH/2);
+        ctx.arcTo(padW/2, -padH/2, padW/2, padH/2, r);
+        ctx.arcTo(padW/2, padH/2, -padW/2, padH/2, r);
+        ctx.arcTo(-padW/2, padH/2, -padW/2, -padH/2, r);
+        ctx.arcTo(-padW/2, -padH/2, padW/2, -padH/2, r);
+        ctx.closePath();
+      };
+      let padFill = '#9aaeff';
+      if(isInfiniteCastle){
+        const depthGrad = ctx.createLinearGradient(0, -padH/2, 0, padH/2);
+        depthGrad.addColorStop(0,'#2d1207');
+        depthGrad.addColorStop(0.16,'#55230d');
+        depthGrad.addColorStop(0.5,'#c6914a');
+        depthGrad.addColorStop(0.84,'#6f2d11');
+        depthGrad.addColorStop(1,'#281006');
+        padFill = depthGrad;
+      }
       if(buffs.PADBOOM.active && !buffs.PADBOOM.exploded){ ctx.globalAlpha=0.5+0.5*Math.sin(nowPad/100); }
-      const r=8*Math.min(scaleX,scaleY);
-      ctx.beginPath();
-      ctx.moveTo(-padW/2 + r, -padH/2);
-      ctx.arcTo(padW/2, -padH/2, padW/2, padH/2, r);
-      ctx.arcTo(padW/2, padH/2, -padW/2, padH/2, r);
-      ctx.arcTo(-padW/2, padH/2, -padW/2, -padH/2, r);
-      ctx.arcTo(-padW/2, -padH/2, padW/2, -padH/2, r);
-      ctx.closePath();
+      const r=8*scaleUnit;
+      drawPadShape();
+      ctx.fillStyle = padFill;
       ctx.fill();
+      if(isInfiniteCastle){
+        ctx.save();
+        drawPadShape();
+        ctx.clip();
+        const plankCount = Math.max(6, Math.round(padW / (72*scaleUnit)));
+        const plankWidth = padW / plankCount;
+        const seamWidth = Math.max(1.1, 0.85*scaleUnit);
+        for(let i=0;i<plankCount;i++){
+          const left = -padW/2 + i*plankWidth;
+          const right = left + plankWidth;
+          const plankGrad = ctx.createLinearGradient(left, 0, right, 0);
+          plankGrad.addColorStop(0,'#371507');
+          plankGrad.addColorStop(0.18,'#6d2c10');
+          plankGrad.addColorStop(0.52,'#d5a158');
+          plankGrad.addColorStop(0.82,'#803914');
+          plankGrad.addColorStop(1,'#301207');
+          ctx.fillStyle = plankGrad;
+          ctx.fillRect(left, -padH/2, plankWidth, padH);
+
+          const inset = plankWidth*0.18;
+          const satin = ctx.createLinearGradient(0, -padH/2, 0, padH/2);
+          satin.addColorStop(0,'rgba(255,240,210,0.14)');
+          satin.addColorStop(0.48,'rgba(255,222,170,0.22)');
+          satin.addColorStop(1,'rgba(150,80,40,0.08)');
+          ctx.fillStyle = satin;
+          ctx.fillRect(left+inset, -padH/2, Math.max(plankWidth-2*inset, seamWidth*2), padH);
+
+          ctx.fillStyle = 'rgba(38,16,8,0.55)';
+          ctx.fillRect(right - seamWidth, -padH/2, seamWidth, padH);
+          if(i === 0){
+            ctx.fillRect(left, -padH/2, seamWidth, padH);
+          }
+        }
+
+        const crossbandWidth = Math.max(3, 3.6*scaleUnit);
+        const crossY1 = -padH/2 + padH*0.26;
+        const crossY2 = padH/2 - padH*0.26;
+        const crossGrad = ctx.createLinearGradient(-padW/2, 0, padW/2, 0);
+        crossGrad.addColorStop(0,'rgba(58,24,12,0.78)');
+        crossGrad.addColorStop(0.5,'rgba(176,108,52,0.58)');
+        crossGrad.addColorStop(1,'rgba(58,24,12,0.78)');
+        ctx.fillStyle = crossGrad;
+        ctx.fillRect(-padW/2, crossY1 - crossbandWidth/2, padW, crossbandWidth);
+        ctx.fillRect(-padW/2, crossY2 - crossbandWidth/2, padW, crossbandWidth);
+
+        const jewelSize = Math.max(4, 4.6*scaleUnit);
+        const jewelOffset = padW/2 - Math.min(padW*0.18, 48*scaleUnit);
+        ctx.fillStyle = '#d9b97a';
+        ctx.strokeStyle = 'rgba(38,16,8,0.65)';
+        ctx.lineWidth = Math.max(0.9, 0.8*scaleUnit);
+        for(const y of [crossY1, crossY2]){
+          for(const x of [-jewelOffset, jewelOffset]){
+            ctx.save();
+            ctx.translate(x, y);
+            ctx.rotate(Math.PI/4);
+            ctx.fillRect(-jewelSize/2, -jewelSize/2, jewelSize, jewelSize);
+            ctx.strokeRect(-jewelSize/2, -jewelSize/2, jewelSize, jewelSize);
+            ctx.restore();
+          }
+        }
+
+        const lacquer = ctx.createLinearGradient(0, -padH/2, 0, padH/2);
+        lacquer.addColorStop(0,'rgba(255,255,255,0.26)');
+        lacquer.addColorStop(0.5,'rgba(255,224,180,0.1)');
+        lacquer.addColorStop(1,'rgba(120,58,30,0.28)');
+        ctx.globalCompositeOperation = 'lighter';
+        ctx.fillStyle = lacquer;
+        ctx.fillRect(-padW/2, -padH/2, padW, padH);
+
+        const halo = ctx.createRadialGradient(0, -padH*0.08, padH*0.18, 0, 0, padW*0.72);
+        halo.addColorStop(0,'rgba(255,240,205,0.32)');
+        halo.addColorStop(0.6,'rgba(255,210,150,0.12)');
+        halo.addColorStop(1,'rgba(90,40,20,0.0)');
+        ctx.fillStyle = halo;
+        ctx.fillRect(-padW/2, -padH/2, padW, padH);
+        ctx.globalCompositeOperation = 'source-over';
+
+        ctx.restore();
+
+        drawPadShape();
+        ctx.lineWidth = Math.max(2.8, 3.6*scaleUnit);
+        ctx.strokeStyle = 'rgba(222,182,112,0.92)';
+        ctx.stroke();
+
+        drawPadShape();
+        ctx.lineWidth = Math.max(1.4, 2.1*scaleUnit);
+        ctx.strokeStyle = 'rgba(44,20,8,0.85)';
+        ctx.stroke();
+
+        drawPadShape();
+        ctx.lineWidth = Math.max(0.8, 1.2*scaleUnit);
+        ctx.strokeStyle = 'rgba(255,236,204,0.45)';
+        ctx.setLineDash([Math.max(6, 12*scaleUnit), Math.max(14, 24*scaleUnit)]);
+        ctx.stroke();
+        ctx.setLineDash([]);
+      }
       if(buffs.HOLE.active){
         if(!orientLeft){ const gapW=padW/3; ctx.clearRect(-padW/2+padW/3, -padH/2, gapW, padH); }
         else { const gapH=padH/3; ctx.clearRect(-padW/2, -padH/2+padH/3, padW, gapH); }

--- a/skin.js
+++ b/skin.js
@@ -188,13 +188,39 @@
     label: '和風．無限之城',
     selectLabel: '和風．無限之城',
     cssSkin: '和風．無限之城',
-    lifeIcon: `<svg viewBox="0 0 48 48" aria-hidden="true">
-      <g fill="none" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M6 38.5 L39.5 5" stroke="#fdf2da" stroke-width="3"/>
-        <path d="m34 11 4.2 4.2" stroke="#fef5e6" stroke-width="2.4"/>
-        <path d="m10.2 35 4.4 4.4" stroke="#431010" stroke-width="4.4"/>
-        <path d="m13.2 31.8 4 4" stroke="#b23a32" stroke-width="3.4"/>
-        <path d="m17.2 28.2 3.4 3.4" stroke="#fdf2da" stroke-width="2.2"/>
+    lifeIcon: `<svg viewBox="0 0 64 64" aria-hidden="true" role="img">
+      <defs>
+        <linearGradient id="katana-castle-blade" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stop-color="#fdfcf7" />
+          <stop offset="52%" stop-color="#d9e4ef" />
+          <stop offset="100%" stop-color="#f5efe3" />
+        </linearGradient>
+        <linearGradient id="katana-castle-edge" x1="0%" y1="0%" x2="100%" y2="0%">
+          <stop offset="0%" stop-color="rgba(255,255,255,0.0)" />
+          <stop offset="35%" stop-color="rgba(255,255,255,0.55)" />
+          <stop offset="80%" stop-color="rgba(255,255,255,0.0)" />
+        </linearGradient>
+        <linearGradient id="katana-castle-wrap" x1="0%" y1="0%" x2="0%" y2="100%">
+          <stop offset="0%" stop-color="#3a1409" />
+          <stop offset="50%" stop-color="#7b2d16" />
+          <stop offset="100%" stop-color="#2b0c06" />
+        </linearGradient>
+      </defs>
+      <g transform="rotate(-40 32 32)">
+        <path fill="#1f0b05" opacity="0.32" d="M24.6 8.6L38.8 33.6L34.4 34.8C30.7 23.4 25 13 18.4 4.6Z" />
+        <path fill="url(#katana-castle-blade)" d="M33.4 7.2L48.4 36L42.8 37.4L33.1 17.6L26 53.8L19.8 52.8Z" />
+        <path fill="url(#katana-castle-edge)" d="M35.6 9.2L47.6 33.8L44.8 34.6C41.9 26.2 37.8 18.3 33.4 11.8L27.2 46.8L24.2 46.4Z" opacity="0.7" />
+        <path fill="#0d0502" d="M21 40.5h22.4c1.8 0 3.4 1.1 4.1 2.7l.4 1c.8 2-0.2 4.2-2.2 5.1-2.3 1-4.9 1.6-7.6 1.6H26.4c-2.4 0-4.7-.5-6.8-1.5-2-.9-2.9-3.3-1.9-5.3l.6-1.1c.8-1.6 2.4-2.5 4.1-2.5z" />
+        <path fill="#2a150c" d="M23.4 40.4h17.2c2 0 3.6 1.6 3.6 3.6v1.5c0 3-2.4 5.4-5.4 5.4H25.2c-3 0-5.4-2.4-5.4-5.4V44c0-2 1.6-3.6 3.6-3.6z" />
+        <path fill="rgba(255,230,180,0.18)" d="M24.4 41.2h15.2c1.6 0 2.8 1.3 2.8 2.8v1c0 2.4-1.9 4.3-4.3 4.3H25.9c-2.4 0-4.3-1.9-4.3-4.3V44c0-1.6 1.3-2.8 2.8-2.8z" />
+        <rect x="23.8" y="38" width="16.4" height="4.2" rx="2.1" fill="#120603" opacity="0.82" />
+        <rect x="25.6" y="46.6" width="13.2" height="10.2" rx="3.2" fill="url(#katana-castle-wrap)" />
+        <rect x="27.2" y="48.8" width="10" height="6" rx="2.4" fill="rgba(255,220,170,0.26)" />
+        <rect x="28" y="49.8" width="1.6" height="4.2" rx="0.8" fill="#2b0c06" />
+        <rect x="31" y="49.8" width="1.6" height="4.2" rx="0.8" fill="#2b0c06" />
+        <rect x="34" y="49.8" width="1.6" height="4.2" rx="0.8" fill="#2b0c06" />
+        <rect x="29.6" y="55.6" width="4.8" height="3.4" rx="1.2" fill="#d8b163" />
+        <rect x="30.6" y="56.4" width="2.8" height="1.6" rx="0.8" fill="#6b3d16" />
       </g>
     </svg>`,
     canvas: {


### PR DESCRIPTION
## Summary
- replace the 和風．無限之城 life indicator with a filled, angled katana icon to ensure the HUD displays the correct thematic graphic
- restyle the 和風．無限之城 paddle rendering with ornate planks, gilded inlays, and lacquered highlights for a refined castle floor look

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68d7e1b349bc83288e21b3df766d8c9c