### PR TITLE
Set Blade Hell slash delay to 700ms for all waves

### DIFF
--- a/index.html
+++ b/index.html
@@ -2471,10 +2471,10 @@ select optgroup { color: #0b1022; }
       countdownEnd:0,
       waveDefs:[
         {rounds:3, points:3, pointInterval:500, roundInterval:1000, slashDelay:700},
-        {rounds:3, points:2, pointInterval:200, roundInterval:1000, slashDelay:200},
-        {rounds:3, points:3, pointInterval:200, roundInterval:1000, slashDelay:200},
-        {rounds:3, points:4, pointInterval:200, roundInterval:1000, slashDelay:200},
-        {rounds:1, points:20, pointInterval:300, roundInterval:0, slashDelay:100}
+        {rounds:3, points:2, pointInterval:200, roundInterval:1000, slashDelay:700},
+        {rounds:3, points:3, pointInterval:200, roundInterval:1000, slashDelay:700},
+        {rounds:3, points:4, pointInterval:200, roundInterval:1000, slashDelay:700},
+        {rounds:1, points:20, pointInterval:300, roundInterval:0, slashDelay:700}
       ],
       waveIndex:-1,
       waveState:null,


### PR DESCRIPTION
## Summary
- set every Blade Hell wave to use a 700ms slash delay so slashes always follow the telegraph by the same interval

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68daae2863e48328add4442761cfca13