### PR TITLE
Adjust blade hell timings for telegraphs and boss return

### DIFF
--- a/index.html
+++ b/index.html
@@ -2470,11 +2470,11 @@ select optgroup { color: #0b1022; }
       countdownStart:0,
       countdownEnd:0,
       waveDefs:[
-        {rounds:3, points:3, pointInterval:500, roundInterval:1000, slashDelay:500},
-        {rounds:3, points:2, pointInterval:200, roundInterval:1000, slashDelay:500},
-        {rounds:3, points:3, pointInterval:200, roundInterval:1000, slashDelay:500},
-        {rounds:3, points:4, pointInterval:200, roundInterval:1000, slashDelay:500},
-        {rounds:1, points:30, pointInterval:100, roundInterval:0, slashDelay:500}
+        {rounds:3, points:3, pointInterval:500, roundInterval:1000, slashDelay:300},
+        {rounds:3, points:2, pointInterval:200, roundInterval:1000, slashDelay:300},
+        {rounds:3, points:3, pointInterval:200, roundInterval:1000, slashDelay:300},
+        {rounds:3, points:4, pointInterval:200, roundInterval:1000, slashDelay:300},
+        {rounds:1, points:30, pointInterval:100, roundInterval:0, slashDelay:300}
       ],
       waveIndex:-1,
       waveState:null,
@@ -2643,6 +2643,12 @@ select optgroup { color: #0b1022; }
         attack.endingLockBase = demonBoss.baseY;
         demonBoss.x = beamX;
         demonBoss.baseY = attack.endingLockBase;
+        const reappearLead=300;
+        const endBeamVanish=attack.endBeam.vanishAt||0;
+        if(endBeamVanish>0){
+          const desiredReturn=endBeamVanish - reappearLead;
+          demonBoss.hiddenUntil = Math.max(demonBoss.hiddenUntil||0, desiredReturn);
+        }
         demonEventShakeUntil=now+3200;
         beginBladeHellBallRelease(now);
       }


### PR DESCRIPTION
## Summary
- shorten blade hell telegraph delay so slashes follow 0.3s after the red glow
- keep the demon boss hidden until the end beam is nearly gone before reappearing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e00a4c418483289b2aa03652ea9103