### PR TITLE
Fix abyss shatter radial gradient crash

### DIFF
--- a/index.html
+++ b/index.html
@@ -3766,7 +3766,7 @@ select optgroup { color: #0b1022; }
         ctx.save();
         ctx.translate(cx, cy);
         ctx.globalCompositeOperation='lighter';
-        const glow=ctx.createRadialGradient(0,0,0,0,outer);
+        const glow=ctx.createRadialGradient(0,0,0,0,0,outer);
         glow.addColorStop(0,`rgba(255,255,255,${0.45*fade})`);
         glow.addColorStop(0.35,`rgba(240,215,255,${0.55*fade})`);
         glow.addColorStop(0.78,`rgba(160,100,255,${0.45*fade})`);
@@ -3858,7 +3858,7 @@ select optgroup { color: #0b1022; }
         ctx.save();
         ctx.translate(cx, cy);
         ctx.globalCompositeOperation='lighter';
-        const core=ctx.createRadialGradient(0,0,0,0,coreRadius);
+        const core=ctx.createRadialGradient(0,0,0,0,0,coreRadius);
         core.addColorStop(0,`rgba(255,255,255,${0.9*fade})`);
         core.addColorStop(0.55,`rgba(255,210,255,${0.65*fade})`);
         core.addColorStop(1,'rgba(150,70,220,0)');


### PR DESCRIPTION
## Summary
- pass both center coordinates when constructing the abyss nova explosion gradient so the canvas API call is valid
- update the abyss nova core gradient to use the full six-argument signature and avoid runtime exceptions that freeze the encounter

## Testing
- python - <<'PY' ...
- Playwright automation to load level 20 and wait through abyss shatter (no page errors)


------
https://chatgpt.com/codex/tasks/task_e_68e383edc8d88328ba0708cbad3ba8ea