### PR TITLE
Align Abyss Shatter countdown with Blade Hell display

### DIFF
--- a/index.html
+++ b/index.html
@@ -3505,7 +3505,7 @@ select optgroup { color: #0b1022; }
     demonBoss.lowKnockbacks=0;
     demonBoss.lastKnockbackAt=now;
     demonBoss.attackAura='abyssShatter';
-    demonEventMarquee={text:'危險！ 魔王埃里赫曼即將施展深淵破碎!', start:now, fadeStart:now+10000, end:now+10000, style:'elegant', countdown:{start:now, end:now+10000, inline:true}};
+    demonEventMarquee={text:'危險！ 魔王埃里赫曼即將施展深淵破碎!', start:now, fadeStart:now+10000, end:now+10000, style:'elegant', countdown:{start:now, end:now+10000}};
   }
 
   function updateDemonAbyssShatter(now, dt){


### PR DESCRIPTION
## Summary
- align the Abyss Shatter 10-second countdown styling with Blade Hell by using the marquee countdown layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4119471388328a3578ee2ceb6fe36