### PR TITLE
Adjust win overlay thumbnail scaling for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,7 +333,7 @@
     .gameover .backdrop{position:absolute;inset:0;background:linear-gradient(180deg, rgba(0,0,0,.75), rgba(0,0,0,.88));}
     .gameover .center{position:relative;z-index:2;text-align:center;background:linear-gradient(180deg, rgba(10,14,30,.85), rgba(10,14,30,.75));padding:18px 22px;border:1px solid var(--glass-stroke);border-radius:16px;box-shadow:0 20px 90px rgba(0,0,0,.5)}
     .win .backdrop{position:absolute;inset:0;background:linear-gradient(180deg, rgba(4,8,20,.62), rgba(6,10,24,.82));}
-    .thumb-ring{position:absolute;inset:16px;pointer-events:none;display:grid;grid-template-columns:repeat(5,minmax(0,1fr));grid-template-rows:repeat(4,minmax(0,1fr));grid-auto-rows:1fr;gap:10px;opacity:.95}
+    .thumb-ring{position:absolute;inset:16px;pointer-events:none;display:grid;grid-template-columns:repeat(5,minmax(0,1fr));grid-template-rows:repeat(4,minmax(0,1fr));grid-auto-rows:1fr;gap:10px;opacity:.95;--ring-scale:1;transform:scale(var(--ring-scale));transform-origin:center}
     .thumb-ring img{width:100%;height:100%;object-fit:cover;object-position:center top;border-radius:14px;box-shadow:0 12px 36px rgba(0,0,0,.55);transform:scale(0.92);transition:transform .4s ease;}
     .thumb-ring img:nth-child(odd){transform:scale(0.9);}
     .thumb-ring img:nth-child(4n){transform:scale(0.94);}
@@ -350,6 +350,7 @@
         pointer-events:none;
         align-items:stretch;
         justify-items:stretch;
+        --ring-scale:.92;
       }
       .thumb-ring::after{content:none;}
       .thumb-ring img{
@@ -372,12 +373,15 @@
     }
     @media (max-width:480px){
       .win .center{width:min(328px,86vw);}
-      .thumb-ring{gap:clamp(2px,1.4vw,6px);}
+      .thumb-ring{gap:clamp(2px,1.4vw,6px);--ring-scale:.84;}
       .thumb-ring img{border-radius:clamp(6px,3vw,14px);}
     }
     @media (max-width:380px){
       .win{padding:clamp(14px,7vh,28px) 0;}
-      .thumb-ring{inset:clamp(6px,7vw,36px) clamp(10px,9vw,44px);}
+      .thumb-ring{inset:clamp(6px,7vw,36px) clamp(10px,9vw,44px);--ring-scale:.78;}
+    }
+    @media (max-width:340px){
+      .thumb-ring{--ring-scale:.72;}
     }
     .win .center{position:relative;z-index:2;text-align:center;background:linear-gradient(180deg, rgba(10,14,30,.85), rgba(10,14,30,.75));padding:18px 22px;border:1px solid var(--glass-stroke);border-radius:16px;box-shadow:0 20px 90px rgba(0,0,0,.5)}
     .win h2{margin:4px 0 6px;font-size:28px;letter-spacing:2px}


### PR DESCRIPTION
## Summary
- add a responsive scale variable to the win overlay thumb grid and tune it for small breakpoints
- keep the 5×4 layout while shrinking thumbnails on narrow mobile viewports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e53ffba3548328ada6bc2615896da3