### PR TITLE
Adjust win screen thumbnail scaling

### DIFF
--- a/index.html
+++ b/index.html
@@ -334,9 +334,9 @@
     .gameover .center{position:relative;z-index:2;text-align:center;background:linear-gradient(180deg, rgba(10,14,30,.85), rgba(10,14,30,.75));padding:18px 22px;border:1px solid var(--glass-stroke);border-radius:16px;box-shadow:0 20px 90px rgba(0,0,0,.5)}
     .win .backdrop{position:absolute;inset:0;background:linear-gradient(180deg, rgba(4,8,20,.62), rgba(6,10,24,.82));}
     .thumb-ring{position:absolute;inset:16px;pointer-events:none;display:grid;grid-template-columns:repeat(5,minmax(0,1fr));grid-template-rows:repeat(4,minmax(0,1fr));grid-auto-rows:1fr;gap:10px;opacity:.95}
-    .thumb-ring img{width:100%;height:100%;object-fit:cover;object-position:center top;border-radius:14px;box-shadow:0 12px 36px rgba(0,0,0,.55);transform:scale(0.92);transition:transform .4s ease;}
-    .thumb-ring img:nth-child(odd){transform:scale(0.9);}
-    .thumb-ring img:nth-child(4n){transform:scale(0.94);}
+    .thumb-ring img{width:100%;height:100%;object-fit:cover;object-position:center top;border-radius:14px;box-shadow:0 12px 36px rgba(0,0,0,.55);transform:scale(0.86);transition:transform .4s ease;background:rgba(14,20,34,.4);}
+    .thumb-ring img:nth-child(odd){transform:scale(0.82);}
+    .thumb-ring img:nth-child(4n){transform:scale(0.88);}
     @media (max-width:640px){
       .thumb-ring{
         position:absolute;
@@ -359,11 +359,11 @@
         object-position:center top;
         border-radius:clamp(8px,3vw,16px);
         box-shadow:0 14px 38px rgba(0,0,0,.5);
-        transform:scale(.88);
+        transform:scale(.8);
         background:rgba(14,20,34,.4);
       }
-      .thumb-ring img:nth-child(odd){transform:scale(.84);}
-      .thumb-ring img:nth-child(4n){transform:scale(.9);}
+      .thumb-ring img:nth-child(odd){transform:scale(.76);}
+      .thumb-ring img:nth-child(4n){transform:scale(.82);}
     }
     @media (max-width:640px){
       .win{flex-direction:column;justify-content:center;align-items:center;padding:clamp(18px,6vh,34px) 0;}


### PR DESCRIPTION
## Summary
- reduce the scale of the victory thumbnail grid images so more of each illustration is visible
- update responsive breakpoints to keep the tighter framing consistent on smaller screens

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e541e6d1688328ac836c14e68a61c3