### PR TITLE
Adjust final victory screen thumbnail sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,10 +333,10 @@
     .gameover .backdrop{position:absolute;inset:0;background:linear-gradient(180deg, rgba(0,0,0,.75), rgba(0,0,0,.88));}
     .gameover .center{position:relative;z-index:2;text-align:center;background:linear-gradient(180deg, rgba(10,14,30,.85), rgba(10,14,30,.75));padding:18px 22px;border:1px solid var(--glass-stroke);border-radius:16px;box-shadow:0 20px 90px rgba(0,0,0,.5)}
     .win .backdrop{position:absolute;inset:0;background:linear-gradient(180deg, rgba(4,8,20,.62), rgba(6,10,24,.82));}
-    .thumb-ring{position:absolute;inset:16px;pointer-events:none;display:grid;grid-template-columns:repeat(5,minmax(0,1fr));grid-template-rows:repeat(4,minmax(0,1fr));grid-auto-rows:1fr;gap:6px;opacity:.95}
-    .thumb-ring img{width:100%;height:100%;object-fit:cover;object-position:center top;border-radius:14px;box-shadow:0 12px 36px rgba(0,0,0,.55);transform:scale(0.5);transform-origin:center;transition:transform .4s ease;background:rgba(14,20,34,.4);}
-    .thumb-ring img:nth-child(odd){transform:scale(0.5);}
-    .thumb-ring img:nth-child(4n){transform:scale(0.5);}
+    .thumb-ring{position:absolute;inset:16px;pointer-events:none;display:grid;grid-template-columns:repeat(5,minmax(0,1fr));grid-template-rows:repeat(4,minmax(0,1fr));grid-auto-rows:1fr;gap:2px;opacity:.95;align-items:center;justify-items:center}
+    .thumb-ring img{width:100%;height:100%;object-fit:cover;object-position:center top;border-radius:14px;box-shadow:0 12px 36px rgba(0,0,0,.55);transform:scale(0.3);transform-origin:center;transition:transform .4s ease;background:rgba(14,20,34,.4);}
+    .thumb-ring img:nth-child(odd){transform:scale(0.3);}
+    .thumb-ring img:nth-child(4n){transform:scale(0.3);}
     @media (max-width:640px){
       .thumb-ring{
         position:absolute;
@@ -344,12 +344,12 @@
         display:grid;
         grid-template-columns:repeat(5,minmax(0,1fr));
         grid-template-rows:repeat(4,minmax(0,1fr));
-        gap:clamp(3px,1.4vw,8px);
+        gap:clamp(1px,0.8vw,4px);
         padding:0;
         opacity:.94;
         pointer-events:none;
-        align-items:stretch;
-        justify-items:stretch;
+        align-items:center;
+        justify-items:center;
       }
       .thumb-ring::after{content:none;}
       .thumb-ring img{
@@ -359,11 +359,11 @@
         object-position:center top;
         border-radius:clamp(8px,3vw,16px);
         box-shadow:0 14px 38px rgba(0,0,0,.5);
-        transform:scale(.5);
+        transform:scale(.3);
         background:rgba(14,20,34,.4);
       }
-      .thumb-ring img:nth-child(odd){transform:scale(.5);}
-      .thumb-ring img:nth-child(4n){transform:scale(.5);}
+      .thumb-ring img:nth-child(odd){transform:scale(.3);}
+      .thumb-ring img:nth-child(4n){transform:scale(.3);}
     }
     @media (max-width:640px){
       .win{flex-direction:column;justify-content:center;align-items:center;padding:clamp(18px,6vh,34px) 0;}
@@ -372,7 +372,7 @@
     }
     @media (max-width:480px){
       .win .center{width:min(328px,86vw);}
-      .thumb-ring{gap:clamp(2px,1vw,4px);}
+      .thumb-ring{gap:clamp(1px,0.6vw,3px);}
       .thumb-ring img{border-radius:clamp(6px,3vw,14px);}
     }
     @media (max-width:380px){


### PR DESCRIPTION
## Summary
- tighten the final victory thumbnail grid while keeping the 5×4 arrangement
- scale the character thumbnails down to 30% across desktop and mobile breakpoints

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e550d82f188328857560ea14b27abc