### PR TITLE
Tighten win gallery grid spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,18 +333,18 @@
     .gameover .backdrop{position:absolute;inset:0;background:linear-gradient(180deg, rgba(0,0,0,.75), rgba(0,0,0,.88));}
     .gameover .center{position:relative;z-index:2;text-align:center;background:linear-gradient(180deg, rgba(10,14,30,.85), rgba(10,14,30,.75));padding:18px 22px;border:1px solid var(--glass-stroke);border-radius:16px;box-shadow:0 20px 90px rgba(0,0,0,.5)}
     .win .backdrop{position:absolute;inset:0;background:linear-gradient(180deg, rgba(4,8,20,.62), rgba(6,10,24,.82));}
-    .thumb-ring{position:absolute;inset:16px;pointer-events:none;display:grid;grid-template-columns:repeat(5,minmax(0,1fr));grid-template-rows:repeat(4,minmax(0,1fr));grid-auto-rows:1fr;gap:2px;opacity:.95;align-items:center;justify-items:center}
-    .thumb-ring img{width:100%;height:100%;object-fit:cover;object-position:center top;border-radius:14px;box-shadow:0 12px 36px rgba(0,0,0,.55);transform:scale(0.3);transform-origin:center;transition:transform .4s ease;background:rgba(14,20,34,.4);}
-    .thumb-ring img:nth-child(odd){transform:scale(0.3);}
-    .thumb-ring img:nth-child(4n){transform:scale(0.3);}
+    .thumb-ring{position:absolute;inset:clamp(6px,2vw,18px);pointer-events:none;display:grid;grid-template-columns:repeat(5,minmax(0,1fr));grid-template-rows:repeat(4,minmax(0,1fr));grid-auto-rows:1fr;gap:clamp(0px,0.2vw,1.5px);opacity:.95;align-items:center;justify-items:center}
+    .thumb-ring img{width:100%;height:100%;object-fit:cover;object-position:center top;border-radius:12px;box-shadow:0 12px 36px rgba(0,0,0,.45);transform:scale(1);transform-origin:center;transition:transform .4s ease, box-shadow .4s ease;background:rgba(14,20,34,.35);}
+    .thumb-ring img:nth-child(odd){transform:scale(1);}
+    .thumb-ring img:nth-child(4n){transform:scale(1);}
     @media (max-width:640px){
       .thumb-ring{
         position:absolute;
-        inset:clamp(6px,5vw,28px) clamp(8px,6vw,32px);
+        inset:clamp(6px,4vw,24px) clamp(6px,5vw,26px);
         display:grid;
         grid-template-columns:repeat(5,minmax(0,1fr));
         grid-template-rows:repeat(4,minmax(0,1fr));
-        gap:clamp(1px,0.8vw,4px);
+        gap:clamp(0px,0.3vw,1.5px);
         padding:0;
         opacity:.94;
         pointer-events:none;
@@ -358,12 +358,12 @@
         object-fit:cover;
         object-position:center top;
         border-radius:clamp(8px,3vw,16px);
-        box-shadow:0 14px 38px rgba(0,0,0,.5);
-        transform:scale(.3);
-        background:rgba(14,20,34,.4);
+        box-shadow:0 14px 32px rgba(0,0,0,.45);
+        transform:scale(1);
+        background:rgba(14,20,34,.32);
       }
-      .thumb-ring img:nth-child(odd){transform:scale(.3);}
-      .thumb-ring img:nth-child(4n){transform:scale(.3);}
+      .thumb-ring img:nth-child(odd){transform:scale(1);}
+      .thumb-ring img:nth-child(4n){transform:scale(1);}
     }
     @media (max-width:640px){
       .win{flex-direction:column;justify-content:center;align-items:center;padding:clamp(18px,6vh,34px) 0;}
@@ -372,7 +372,7 @@
     }
     @media (max-width:480px){
       .win .center{width:min(328px,86vw);}
-      .thumb-ring{gap:clamp(1px,0.6vw,3px);}
+      .thumb-ring{gap:clamp(0px,0.25vw,1.2px);}
       .thumb-ring img{border-radius:clamp(6px,3vw,14px);}
     }
     @media (max-width:380px){


### PR DESCRIPTION
## Summary
- widen each tile in the victory gallery grid while keeping the 5×4 layout
- shrink margins and gaps so the thumbnails nearly touch edge to edge across screen sizes
- normalize thumbnail scaling so each image fills its cell

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e5c2169c7c8328834752cbb97bc28d