### PR TITLE
Refine mobile win overlay layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -337,11 +337,18 @@
       --ring-cols:5;
       --ring-rows:4;
       --ring-gap:clamp(0px,0.2vw,1.5px);
-      --thumb-scale:0.5;
+      --thumb-scale:0.62;
       position:absolute;
-      inset:clamp(6px,2vw,18px);
+      inset:0;
+      padding:calc(env(safe-area-inset-top) + clamp(8px,4vw,22px))
+              calc(env(safe-area-inset-right) + clamp(8px,4vw,22px))
+              calc(env(safe-area-inset-bottom) + clamp(8px,4vw,22px))
+              calc(env(safe-area-inset-left) + clamp(8px,4vw,22px));
+      box-sizing:border-box;
       pointer-events:none;
       display:grid;
+      width:100%;
+      height:100%;
       grid-template-columns:repeat(var(--ring-cols),minmax(0,1fr));
       grid-auto-rows:calc((100% - (var(--ring-rows) - 1) * var(--ring-gap)) / var(--ring-rows));
       gap:var(--ring-gap);
@@ -356,7 +363,7 @@
       max-width:none;
       max-height:none;
       object-fit:cover;
-      object-position:center top;
+      object-position:center 32%;
       border-radius:12px;
       box-shadow:0 12px 36px rgba(0,0,0,.45);
       transform:scale(var(--thumb-scale));
@@ -367,8 +374,11 @@
     @media (max-width:640px){
       .thumb-ring{
         --ring-gap:clamp(0px,0.3vw,1.5px);
-        inset:clamp(6px,4vw,24px) clamp(6px,5vw,26px);
-        padding:0;
+        --thumb-scale:0.66;
+        padding:calc(env(safe-area-inset-top) + clamp(10px,6vw,30px))
+                calc(env(safe-area-inset-right) + clamp(10px,6vw,30px))
+                calc(env(safe-area-inset-bottom) + clamp(10px,6vw,30px))
+                calc(env(safe-area-inset-left) + clamp(10px,6vw,30px));
         opacity:.94;
       }
       .thumb-ring::after{content:none;}
@@ -380,19 +390,26 @@
     }
     @media (max-width:640px){
       .win{flex-direction:column;justify-content:center;align-items:center;padding:clamp(18px,6vh,34px) 0;}
-      .win .center{order:2;width:min(360px,88vw);margin:0 auto;}
+      .win .center{order:2;max-width:min(320px,82vw);padding:16px 18px;margin:0 auto;}
       .thumb-note{display:block;order:3;margin:16px auto 0;font-size:12px;color:#dbe7ff;opacity:0.85;text-align:center;max-width:min(440px,92vw);line-height:1.5;padding:0 18px;text-shadow:0 1px 2px rgba(0,0,0,.6);}
+      #statsWin{font-size:12px;line-height:1.6;}
     }
     @media (max-width:480px){
-      .win .center{width:min(328px,86vw);}
-      .thumb-ring{--ring-gap:clamp(0px,0.25vw,1.2px);}
+      .win .center{max-width:min(304px,80vw);padding:14px 16px;}
+      .win h2{font-size:26px;}
+      #statsWin{font-size:11.5px;}
+      .thumb-ring{--ring-gap:clamp(0px,0.25vw,1.2px);--thumb-scale:0.7;
+        padding:calc(env(safe-area-inset-top) + clamp(12px,7vw,34px))
+                calc(env(safe-area-inset-right) + clamp(12px,7vw,34px))
+                calc(env(safe-area-inset-bottom) + clamp(12px,7vw,34px))
+                calc(env(safe-area-inset-left) + clamp(12px,7vw,34px));
+      }
       .thumb-ring img{border-radius:clamp(6px,3vw,14px);}
     }
     @media (max-width:380px){
       .win{padding:clamp(14px,7vh,28px) 0;}
-      .thumb-ring{inset:clamp(6px,7vw,36px) clamp(10px,9vw,44px);}
     }
-    .win .center{position:relative;z-index:2;text-align:center;background:linear-gradient(180deg, rgba(10,14,30,.85), rgba(10,14,30,.75));padding:18px 22px;border:1px solid var(--glass-stroke);border-radius:16px;box-shadow:0 20px 90px rgba(0,0,0,.5)}
+    .win .center{position:relative;z-index:2;text-align:center;background:linear-gradient(180deg, rgba(10,14,30,.85), rgba(10,14,30,.75));padding:18px 20px;border:1px solid var(--glass-stroke);border-radius:16px;box-shadow:0 20px 90px rgba(0,0,0,.5);max-width:min(360px,84vw);margin:0 auto}
     .win h2{margin:4px 0 6px;font-size:28px;letter-spacing:2px}
     .win .small{opacity:.8;font-size:12px;margin-top:6px}
     .win .again{margin-top:10px}


### PR DESCRIPTION
## Summary
- center the 5×4 victory gallery grid with safe-area padding so it fills the viewport on phones
- shrink the win stats panel on mobile and tighten typography to remove excess whitespace
- ease the thumbnail scaling so more of each character portrait remains visible in the victory grid

## Testing
- Not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68e636f278b08328972325364b6908f1