### PR TITLE
Center mobile victory thumbnail grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -380,6 +380,14 @@
                 calc(env(safe-area-inset-bottom) + clamp(10px,6vw,30px))
                 calc(env(safe-area-inset-left) + clamp(10px,6vw,30px));
         opacity:.94;
+        left:50%;
+        right:auto;
+        transform:translateX(-50%);
+        width:min(92vw,520px);
+        justify-content:center;
+        align-content:center;
+        justify-items:center;
+        align-items:center;
       }
       .thumb-ring::after{content:none;}
       .thumb-ring img{


### PR DESCRIPTION
## Summary
- center the 5x4 victory thumbnail grid on small screens so it aligns with the dialog overlay
- keep existing layout while ensuring the mobile overlay remains symmetrical within the safe area

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e63fae97d08328b6073fc5746fea34